### PR TITLE
CMake dependencies Update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ target_include_directories(${PROJECT_NAME}_lib PUBLIC
 
 # Link libaries
 target_link_libraries(${PROJECT_NAME}_lib
-        spdlog
+        spdlog::spdlog
         tetgen
         yaml-cpp
         xsimd

--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 
 message(STATUS "Setting up pybind11")
 
-find_package(pybind11 2.9.2)
+find_package(pybind11 2.9.2 QUIET)
 
 if (${pybind11_FOUND})
 

--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -2,10 +2,20 @@ include(FetchContent)
 
 message(STATUS "Setting up pybind11")
 
-#Fetches the version 2.9.2 from the official github of pybind11
-FetchContent_Declare(pybind11
-        GIT_REPOSITORY https://github.com/pybind/pybind11
-        GIT_TAG v2.9.2
-        )
+find_package(pybind11 2.9.2)
 
-FetchContent_MakeAvailable(pybind11)
+if (${pybind11_FOUND})
+
+    message(STATUS "Using local pybind11 installation")
+
+else()
+
+    #Fetches the version 2.9.2 from the official github of pybind11
+    FetchContent_Declare(pybind11
+            GIT_REPOSITORY https://github.com/pybind/pybind11
+            GIT_TAG v2.9.2
+            )
+
+    FetchContent_MakeAvailable(pybind11)
+
+endif()

--- a/cmake/spdlog.cmake
+++ b/cmake/spdlog.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 
 message(STATUS "Setting up spdlog")
 
-find_package(spdlog 1.10.0)
+find_package(spdlog 1.10.0 QUIET)
 
 if (${spdlog_FOUND})
 

--- a/cmake/spdlog.cmake
+++ b/cmake/spdlog.cmake
@@ -2,21 +2,31 @@ include(FetchContent)
 
 message(STATUS "Setting up spdlog")
 
-#Fetches the version 1.9.2 for spdlog
-FetchContent_Declare(spdlog
-        GIT_REPOSITORY https://github.com/gabime/spdlog.git
-        GIT_TAG v1.9.2
-        )
+find_package(spdlog 1.10.0)
 
-# Disable stuff we don't need
-option(SPDLOG_BUILD_EXAMPLE "" OFF)
-option(SPDLOG_BUILD_TESTS "" OFF)
-option(SPDLOG_INSTALL "" OFF)
+if (${spdlog_FOUND})
 
-FetchContent_MakeAvailable(spdlog)
+    message(STATUS "Using local spdlog installation")
 
-# Disable warnings from the library target
-target_compile_options(spdlog PRIVATE -w)
-# Disable warnings from included headers
-get_target_property(propval spdlog INTERFACE_INCLUDE_DIRECTORIES)
-target_include_directories(spdlog SYSTEM PUBLIC "${propval}")
+else()
+
+    #Fetches the version 1.10.0 for spdlog
+    FetchContent_Declare(spdlog
+            GIT_REPOSITORY https://github.com/gabime/spdlog.git
+            GIT_TAG v1.10.0
+            )
+
+    # Disable stuff we don't need
+    option(SPDLOG_BUILD_EXAMPLE "" OFF)
+    option(SPDLOG_BUILD_TESTS "" OFF)
+    option(SPDLOG_INSTALL "" OFF)
+
+    FetchContent_MakeAvailable(spdlog)
+
+    # Disable warnings from the library target
+    target_compile_options(spdlog PRIVATE -w)
+    # Disable warnings from included headers
+    get_target_property(propval spdlog INTERFACE_INCLUDE_DIRECTORIES)
+    target_include_directories(spdlog SYSTEM PUBLIC "${propval}")
+
+endif()

--- a/cmake/tetgen.cmake
+++ b/cmake/tetgen.cmake
@@ -2,6 +2,9 @@ include(FetchContent)
 
 message(STATUS "Setting up tetgen")
 
+# IMPORTANT NOTE
+# We do ot use findPackage here, as we modify the one source file slightly to suppress output via stdout!!!
+
 #Fetches the version 1.6 for tetgen
 FetchContent_Declare(tetgen
         GIT_REPOSITORY https://github.com/libigl/tetgen.git

--- a/cmake/thrust.cmake
+++ b/cmake/thrust.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 
 message(STATUS "Setting up thrust")
 
-find_package(Thrust 1.16)
+find_package(Thrust 1.16 QUIET)
 
 if (${Thrust_FOUND})
 

--- a/cmake/thrust.cmake
+++ b/cmake/thrust.cmake
@@ -2,20 +2,28 @@ include(FetchContent)
 
 message(STATUS "Setting up thrust")
 
-# Fetches the version 1.17.0 of the official NVIDIA Thrust repository
-FetchContent_Declare(thrust
-        GIT_REPOSITORY https://github.com/NVIDIA/thrust.git
-        GIT_TAG 1.17.0
-        )
+find_package(Thrust 1.16)
 
-set(Thrust_DIR ${CMAKE_BINARY_DIR}/_deps/thrust-src/thrust/cmake/)
+if (${Thrust_FOUND})
 
-# Disable stuff not needed
-set(THRUST_ENABLE_HEADER_TESTING "OFF")
-set(THRUST_ENABLE_TESTING "OFF")
-set(THRUST_ENABLE_EXAMPLES "OFF")
+    message(STATUS "Using local thrust installation")
 
-# Set standard CPP Dialect to 17 (default of thrust would be 14)
-set(THRUST_CPP_DIALECT 17)
+else()
+    # Fetches the version 1.16.0 of the official NVIDIA Thrust repository
+    FetchContent_Declare(thrust
+            GIT_REPOSITORY https://github.com/NVIDIA/thrust.git
+            GIT_TAG 1.16.0
+            )
 
-FetchContent_MakeAvailable(thrust)
+    set(Thrust_DIR ${CMAKE_BINARY_DIR}/_deps/thrust-src/thrust/cmake/)
+
+    # Disable stuff not needed
+    set(THRUST_ENABLE_HEADER_TESTING "OFF")
+    set(THRUST_ENABLE_TESTING "OFF")
+    set(THRUST_ENABLE_EXAMPLES "OFF")
+
+    # Set standard CPP Dialect to 17 (default of thrust would be 14)
+    set(THRUST_CPP_DIALECT 17)
+
+    FetchContent_MakeAvailable(thrust)
+endif()

--- a/cmake/thrust.cmake
+++ b/cmake/thrust.cmake
@@ -15,8 +15,6 @@ else()
             GIT_TAG 1.16.0
             )
 
-    set(Thrust_DIR ${CMAKE_BINARY_DIR}/_deps/thrust-src/thrust/cmake/)
-
     # Disable stuff not needed
     set(THRUST_ENABLE_HEADER_TESTING "OFF")
     set(THRUST_ENABLE_TESTING "OFF")

--- a/cmake/xsimd.cmake
+++ b/cmake/xsimd.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 message(STATUS "Setting up xsimd via CMake")
 
 
-find_package(xsimd 8.1.0)
+find_package(xsimd 8.1.0 QUIET)
 
 if (${xsimd_FOUND})
 

--- a/cmake/xsimd.cmake
+++ b/cmake/xsimd.cmake
@@ -2,10 +2,21 @@ include(FetchContent)
 
 message(STATUS "Setting up xsimd via CMake")
 
-#Fetches the version 8.1.0 from the official github of tbb
-FetchContent_Declare(xsimd
-        GIT_REPOSITORY https://github.com/xtensor-stack/xsimd.git
-        GIT_TAG 8.1.0
-        )
 
-FetchContent_MakeAvailable(xsimd)
+find_package(xsimd 8.1.0)
+
+if (${xsimd_FOUND})
+
+    message(STATUS "Using local xsimd installation")
+
+else()
+
+    #Fetches the version 8.1.0 from the official github of tbb
+    FetchContent_Declare(xsimd
+            GIT_REPOSITORY https://github.com/xtensor-stack/xsimd.git
+            GIT_TAG 8.1.0
+            )
+
+    FetchContent_MakeAvailable(xsimd)
+
+endif()

--- a/cmake/yaml.cmake
+++ b/cmake/yaml.cmake
@@ -2,21 +2,31 @@ include(FetchContent)
 
 message(STATUS "Setting up yaml-cpp")
 
-#Fetches the version 0.7.0 for yaml-cpp
-FetchContent_Declare(yaml-cpp
-        GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-        GIT_TAG yaml-cpp-0.7.0
-        )
+find_package(yaml-cpp 0.7.0)
 
-# Disable everything we don't need
-set(YAML_CPP_BUILD_TESTS OFF CACHE INTERNAL "")
-set(YAML_CPP_BUILD_CONTRIB OFF CACHE INTERNAL "")
-set(YAML_CPP_BUILD_TOOLS OFF CACHE INTERNAL "")
+if (${yaml-cpp_FOUND})
 
-FetchContent_MakeAvailable(yaml-cpp)
+    message(STATUS "Using local yaml-cpp installation")
 
-# Disable warnings from the library target
-target_compile_options(yaml-cpp PRIVATE -w)
-# Disable warnings from included headers
-get_target_property(propval yaml-cpp INTERFACE_INCLUDE_DIRECTORIES)
-target_include_directories(yaml-cpp SYSTEM PUBLIC "${propval}")
+else()
+
+    #Fetches the version 0.7.0 for yaml-cpp
+    FetchContent_Declare(yaml-cpp
+            GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
+            GIT_TAG yaml-cpp-0.7.0
+            )
+
+    # Disable everything we don't need
+    set(YAML_CPP_BUILD_TESTS OFF CACHE INTERNAL "")
+    set(YAML_CPP_BUILD_CONTRIB OFF CACHE INTERNAL "")
+    set(YAML_CPP_BUILD_TOOLS OFF CACHE INTERNAL "")
+
+    FetchContent_MakeAvailable(yaml-cpp)
+
+    # Disable warnings from the library target
+    target_compile_options(yaml-cpp PRIVATE -w)
+    # Disable warnings from included headers
+    get_target_property(propval yaml-cpp INTERFACE_INCLUDE_DIRECTORIES)
+    target_include_directories(yaml-cpp SYSTEM PUBLIC "${propval}")
+
+endif()

--- a/cmake/yaml.cmake
+++ b/cmake/yaml.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 
 message(STATUS "Setting up yaml-cpp")
 
-find_package(yaml-cpp 0.7.0)
+find_package(yaml-cpp 0.7.0 QUIET)
 
 if (${yaml-cpp_FOUND})
 

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ class CMakeBuild(build_ext):
 # --------------------------------------------------------------------------------
 setup(
     name="polyhedral_gravity",
-    version="1.0.5",
+    version="1.0.6",
     author="Jonas Schuhmacher",
     author_email="jonas.schuhmacher@tum.de",
     description="Package to compute full gravity tensor of a given constant density polyhedron for arbitrary points",


### PR DESCRIPTION
# Changelog

- Added `find_package(..)` call for most dependencies. This allows:
  - to use the packages provided by conda
  - users who already have dependencies installed do not download additional overhead