### PR TITLE
Update the link to jupyter notebook in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ which is strongly based on the former implementation in FORTRAN.
 ### Results and Plots
 
 Some exemplary results and plots are stored in the
-[jupyter notebook](https://github.com/esa/polyhedral-gravity-model/blob/vertices-checking/script/polyhedral-gravity.ipynb).
+[jupyter notebook](script/polyhedral-gravity.ipynb).
 It also provides a good introduction to the application of
 the python interface.
 


### PR DESCRIPTION
The link to the jupyter notebook was broken and updated as a relative path. The original URL was `https://github.com/esa/polyhedral-gravity-model/blob/vertices-checking/script/polyhedral-gravity.ipynb`, but there is no `vertices-checking` branch. The relative path can ensure validity and is fork-friendly.