### PR TITLE
Create pypi publish workflow

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,82 @@
+name: Build & Publish Python Package
+
+on:
+  release:
+    types: [created]
+    # Only trigger for regular releases, not pre-releases
+    # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release
+    # for more information on the release event
+    prerelease: false
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build wheels (Linux)
+        uses: pypa/cibuildwheel@v2.15.0
+        env:
+          CIBW_BEFORE_BUILD: yum makecache && yum install -y gcc-c++ cmake && pip install ninja
+          CIBW_BUILD: "*manylinux*"
+          CIBW_ARCHS_LINUX: "auto64"
+        with:
+          package-dir: .
+          output-dir: dist
+        if: matrix.os == 'ubuntu-latest'
+      - name: Build wheels (macOS)
+        uses: pypa/cibuildwheel@v2.15.0
+        env:
+          CIBW_BEFORE_BUILD: brew install ninja gcc@12
+          CIBW_ENVIRONMENT: "CC=gcc-12 CXX=g++-12"
+        with:
+          package-dir: .
+          output-dir: dist
+        if: matrix.os == 'macos-latest'
+      - name: Build wheels (Windows)
+        uses: pypa/cibuildwheel@v2.15.0
+        env:
+          CIBW_BEFORE_BUILD: choco install -y ninja cmake mingw
+          CIBW_ARCHS_WINDOWS: "auto64"
+          CIBW_ENVIRONMENT: "CXXFLAGS=-D_hypot=hypot POLYHEDRAL_GRAVITY_PARALLELIZATION=OMP"
+        with:
+          package-dir: .
+          output-dir: dist
+        if: matrix.os == 'windows-latest'
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.whl
+
+  make_sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build SDist
+        run: pipx run build --sdist
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  upload_all:
+    needs: [build_wheels, make_sdist]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/polyhedral-gravity
+      # name: testpypi
+      # url: https://test.pypi.org/p/polyhedral-gravity
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        # with:
+        #   repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -47,6 +47,7 @@ jobs:
           CIBW_BEFORE_BUILD: choco install -y ninja cmake
           CIBW_ARCHS_WINDOWS: "auto64"
           CIBW_TEST_COMMAND: 'python -c "import polyhedral_gravity"'
+          CIBW_ENVIRONMENT: "CXX_FLAGS='/d2FH4-' POLYHEDRAL_GRAVITY_PARALLELIZATION=OMP"
         with:
           package-dir: .
           output-dir: dist

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -62,13 +62,11 @@ jobs:
         with:
           path: dist/*.tar.gz
 
-  upload_all:
+  upload_testpypi:
     needs: [build_wheels, make_sdist]
     environment:
-      name: pypi
-      url: https://pypi.org/p/polyhedral-gravity
-      # name: testpypi
-      # url: https://test.pypi.org/p/polyhedral-gravity
+      name: testpypi
+      url: https://test.pypi.org/p/polyhedral-gravity
     permissions:
       id-token: write
     runs-on: ubuntu-latest
@@ -78,5 +76,51 @@ jobs:
           name: artifact
           path: dist
       - uses: pypa/gh-action-pypi-publish@release/v1
-        # with:
-        #   repository-url: https://test.pypi.org/legacy/
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  check_testpypi:
+    needs: [upload_testpypi]
+    name: Test import on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    if: always()
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        py:
+          [
+            3.7.x,
+            3.8.x,
+            3.9.x,
+            3.10.x,
+            3.11.x,
+            pypy3.7,
+            pypy3.8,
+            pypy3.9,
+            pypy3.10,
+          ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.py }}
+      - name: Install package from testpypi
+        run: pip install --index-url https://test.pypi.org/simple/ polyhedral-gravity
+      - name: Check import
+        run: python -c "import polyhedral_gravity"
+
+  upload_pypi:
+    needs: [build_wheels, make_sdist, check_testpypi]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/polyhedral-gravity
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,6 +9,7 @@ on:
     prerelease: false
 
 jobs:
+  # 1.a Buidl the wheels on a matrix of Windows, MacOS, and Linux plattforms usinbg cibuildwheel
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -18,6 +19,8 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
+        # In case of Linux we need to install compiler and build tools before building the wheels
+        # We further only build the manylinux wheels, but not the musllinux wheels
       - name: Build wheels (Linux)
         uses: pypa/cibuildwheel@v2.15.0
         env:
@@ -29,6 +32,8 @@ jobs:
           package-dir: .
           output-dir: dist
         if: matrix.os == 'ubuntu-latest'
+      # Building on macOS requires an installation of gcc since the default clang compiler
+      # lacks certain features required for building the package
       - name: Build wheels (macOS)
         uses: pypa/cibuildwheel@v2.15.0
         env:
@@ -39,6 +44,7 @@ jobs:
           package-dir: .
           output-dir: dist
         if: matrix.os == 'macos-latest'
+      # Set up the Visual Studio environment on Windows (required, so that CNaje finds the compiler)
       - uses: ilammy/msvc-dev-cmd@v1
         if: matrix.os == 'windows-latest'
       - name: Build wheels (Windows)
@@ -55,6 +61,7 @@ jobs:
         with:
           path: dist/*.whl
 
+  # 1.b Build the source distribution by simply running the build command
   make_sdist:
     name: Make SDist
     runs-on: ubuntu-latest
@@ -66,6 +73,8 @@ jobs:
         with:
           path: dist/*.tar.gz
 
+  # 2. Upload the wheels and the source distribution to testpypi
+  #    using trusted publishing
   upload_testpypi:
     needs: [build_wheels, make_sdist]
     environment:
@@ -83,6 +92,9 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
 
+  # 3. Check if the package can be installed from testpypi
+  #    Notice, that this is more of an install test since the
+  #    import check has already been done in the build_wheels job
   check_testpypi:
     needs: [upload_testpypi]
     name: Test import on ${{ matrix.os }} with ${{ matrix.py }}
@@ -114,6 +126,8 @@ jobs:
       - name: Check import
         run: python -c "import polyhedral_gravity"
 
+  # 4. Upload the wheels to the actualy Python Package Index
+  #    using trusted publishing
   upload_pypi:
     needs: [build_wheels, make_sdist, check_testpypi]
     environment:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -81,7 +81,7 @@ jobs:
 
   check_testpypi:
     needs: [upload_testpypi]
-    name: Test import on ${{ matrix.os }}
+    name: Test import on ${{ matrix.os }} with ${{ matrix.py }}
     runs-on: ${{ matrix.os }}
     if: always()
     strategy:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,6 +24,7 @@ jobs:
           CIBW_BEFORE_BUILD: yum makecache && yum install -y gcc-c++ cmake && pip install ninja
           CIBW_BUILD: "*manylinux*"
           CIBW_ARCHS_LINUX: "auto64"
+          CIBW_TEST_COMMAND: 'python -c "import polyhedral_gravity"'
         with:
           package-dir: .
           output-dir: dist
@@ -33,16 +34,19 @@ jobs:
         env:
           CIBW_BEFORE_BUILD: brew install ninja gcc@12
           CIBW_ENVIRONMENT: "CC=gcc-12 CXX=g++-12"
+          CIBW_TEST_COMMAND: 'python -c "import polyhedral_gravity"'
         with:
           package-dir: .
           output-dir: dist
         if: matrix.os == 'macos-latest'
+      - uses: ilammy/msvc-dev-cmd@v1
+        if: matrix.os == 'windows-latest'
       - name: Build wheels (Windows)
         uses: pypa/cibuildwheel@v2.15.0
         env:
-          CIBW_BEFORE_BUILD: choco install -y ninja cmake mingw
+          CIBW_BEFORE_BUILD: choco install -y ninja cmake
           CIBW_ARCHS_WINDOWS: "auto64"
-          CIBW_ENVIRONMENT: "CXXFLAGS=-D_hypot=hypot POLYHEDRAL_GRAVITY_PARALLELIZATION=OMP"
+          CIBW_TEST_COMMAND: 'python -c "import polyhedral_gravity"'
         with:
           package-dir: .
           output-dir: dist

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -47,7 +47,6 @@ jobs:
           CIBW_BEFORE_BUILD: choco install -y ninja cmake
           CIBW_ARCHS_WINDOWS: "auto64"
           CIBW_TEST_COMMAND: 'python -c "import polyhedral_gravity"'
-          CIBW_ENVIRONMENT: "CXX_FLAGS='/d2FH4-' POLYHEDRAL_GRAVITY_PARALLELIZATION=OMP"
         with:
           package-dir: .
           output-dir: dist

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![GitHub](https://img.shields.io/github/license/esa/polyhedral-gravity-model)
 
 ![PyPI](https://img.shields.io/pypi/v/polyhedral-gravity)
-![Static Badge](https://img.shields.io/badge/platform-linux--64_%7C_windows--64_%7C_osx--64_%7C_linux--arm64_%7C_osx--arm64-lightgrey)
+![Static Badge](https://img.shields.io/badge/platform-linux--64_%7C_win--64_%7C_osx--64_%7C_linux--arm64_%7C_osx--arm64-lightgrey)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/polyhedral-gravity)
 
 ![Conda](https://img.shields.io/conda/v/conda-forge/polyhedral-gravity-model)

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ class CMakeBuild(build_ext):
 # --------------------------------------------------------------------------------
 setup(
     name="polyhedral_gravity",
-    version="2.0",
+    version="2.0.1",
     author="Jonas Schuhmacher",
     author_email="jonas.schuhmacher@tum.de",
     description="Package to compute full gravity tensor of a given constant density polyhedron for arbitrary points",

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ class CMakeBuild(build_ext):
 # --------------------------------------------------------------------------------
 setup(
     name="polyhedral_gravity",
-    version="2.0.2",
+    version="2.0.3",
     author="Jonas Schuhmacher",
     author_email="jonas.schuhmacher@tum.de",
     description="Package to compute full gravity tensor of a given constant density polyhedron for arbitrary points",

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ class CMakeBuild(build_ext):
 # --------------------------------------------------------------------------------
 setup(
     name="polyhedral_gravity",
-    version="2.0.1",
+    version="2.0.2",
     author="Jonas Schuhmacher",
     author_email="jonas.schuhmacher@tum.de",
     description="Package to compute full gravity tensor of a given constant density polyhedron for arbitrary points",


### PR DESCRIPTION
# Changelog

_53 Commit-Tortures later, finally, the CI runs for pypy, CPython on Windows, OSX, and Manylinux (due to psychological reasons, all 53 commits were rebased to one since the commit messages degraded to single letters)_

- Add workflow which builds the `sdist` and `wheels` for pypy, CPython on Windows, OSX, and Manylinux for all Python versions 3.6 - 3.11
- Add automatic upload to PyPi
- *Trusted Publishing* is enabled on the PyPi-side, so no secrets or similar need to be added to the repository



## Details

- Windows
  - We use OpenMP parallelization due to compile issues with GNU
  - We use GNU since MSVC is somehow unavailable in the Docker Image (?)
  - Because Windows GNU `cmath` header has a weird include bug, we do some magic with `CXXFLAGS=-D_hypot=hypot` to fix the namespace issue
- OSX
  - We use TBB
  - We don't use Apple Clang since the Docker Image uses an old MacOS, which has compile issues with C++17
  - We use GCC12
- Linux
  - We use TBB