### PR TITLE
JOSS - PRE REVIEW Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@
 ![Conda](https://img.shields.io/conda/pn/conda-forge/polyhedral-gravity-model)
 ![Conda](https://img.shields.io/conda/dn/conda-forge/polyhedral-gravity-model)
 
+<p align="center">
+  <img src="paper/figures/eros_010.png" width="50%">
+  <br>
+  <em>
+    <a href="https://github.com/gomezzz/geodesyNets/blob/master/3dmeshes/eros_lp.pk">Mesh of (433) Eros</a> with 739 vertices and 1474 faces
+  </em>
+</p>
+
 ## Table of Contents
 
 - [References](#references)
@@ -314,7 +322,7 @@ gravityModel:
 
 #### Output
 
-The calculation outputs the following parameters for every Computation Point _P_:
+The calculation outputs the following parameters for every Computation Point *P*:
 
 |             Name             |      Unit       |                              Comment                              |
 |:----------------------------:|:---------------:|:-----------------------------------------------------------------:|

--- a/paper/figures/churyumov-gerasimenko_010.png
+++ b/paper/figures/churyumov-gerasimenko_010.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18b6d54d622a4bc2a6dd7db7a791925eac9e270b9d079336eb27375a99d9eac3
+size 477592

--- a/paper/figures/churyumov-gerasimenko_100.png
+++ b/paper/figures/churyumov-gerasimenko_100.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3e85372da6cfe119289706ba612a1b3d4c27ed82cfeaf3087b03aa2182ab402
+size 922035

--- a/paper/figures/eros.png
+++ b/paper/figures/eros.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6d791882ae504287541b9ea01ba35eb24b9ba3b780c631979a78028f409afa78
-size 2187893

--- a/paper/figures/eros_010.png
+++ b/paper/figures/eros_010.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e5af62cde7c4ecd2b08ebecdd74847d288e77e1340dd74397267fd0feb3b2a7
+size 536383

--- a/paper/figures/eros_100.png
+++ b/paper/figures/eros_100.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e59033d97a5130e6306a3606759da2d239fc2096b5d4a08869ad0da6931cc2d
+size 994077

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,4 +1,5 @@
 @article{tsoulis2009recursive,
+  doi={10.1007/s00190-009-0310-9},
   title={Recursive algorithms for the computation of the potential harmonic coefficients of a constant density polyhedron},
   author={Tsoulis, Dimitrios and Jamet, Olivier and Verdun, J{\'e}r{\^o}me and Gonindard, Nicolas},
   journal={Journal of Geodesy},
@@ -9,6 +10,7 @@
 }
 
 @article{tsoulis2012analytical,
+  doi={10.1190/geo2010-0334.1},
   title={Analytical computation of the full gravity tensor of a homogeneous arbitrarily shaped polyhedral source using line integrals},
   author={Tsoulis, Dimitrios},
   journal={Geophysics},
@@ -20,6 +22,7 @@
 }
 
 @article{tsoulis2021computational,
+  doi={10.1111/1365-2478.13134},
   title={A computational review of the line integral analytical formulation of the polyhedral gravity signal},
   author={Tsoulis, Dimitrios and Gavriilidou, Georgia},
   journal={Geophysical Prospecting},
@@ -31,6 +34,7 @@
 }
 
 @article{izzo2022geodesy,
+  doi={10.1038/s44172-022-00050-3},
   title={Geodesy of irregular small bodies via neural density fields},
   author={Izzo, Dario and G{\'o}mez, Pablo},
   journal={Communications Engineering},
@@ -46,13 +50,15 @@
   author={Jonas Schuhmacher and Fabio Gratl and Dario Izzo and Pablo G{\'o}mez},
   booktitle={Proceedings of the 12th International Conference on Guidance, Navigation \& Control Systems (GNC)},
   year={2023},
+  url={https://az659834.vo.msecnd.net/eventsairwesteuprod/production-atpi-public/b1e566f6284f4814b1c733ec08e4d136}
 }
 
 @inproceedings{marak2023trajectory,
 	title={{Trajectory optimization of a spacecraft swarm orbiting around 67P/Churyumov-Gerasimenko}},
 	author={Mar{å}k, Rasmus and Blazquez, E. and G{\'o}mez, Pablo},
 	booktitle={Proceedings of the 9th International Conference on Astrodynamics Tools and Techniques, ICATT},
-	year={2023}
+	year={2023},
+  url={https://az659834.vo.msecnd.net/eventsairwesteuprod/production-atpi-public/6f457b8c46dd40ab826a9160c3110b56}
 }
 
 
@@ -61,9 +67,11 @@
 	author={Schuhmacher, Jonas},
 	year={2022},
 	institution={Technische Universität München},
+  url={https://mediatum.ub.tum.de/doc/1695208/1695208.pdf}
 }
 
 @article{tsoulis2001singularities,
+  doi={10.1190/1.1444944},
   title={On the singularities of the gravity field of a homogeneous polyhedral body},
   author={Tsoulis, Dimitrios and Petrovi{\'c}, Sveto},
   journal={Geophysics},
@@ -75,6 +83,7 @@
 }
 
 @article{petrovic1996determination,
+  doi={10.1007/s001900050074},
   title={Determination of the potential of homogeneous polyhedral bodies using line integrals},
   author={Petrovi{\'c}, S},
   journal={Journal of Geodesy},
@@ -85,6 +94,7 @@
 }
 
 @article{hang2015tetgen,
+  doi={10.1145/2629697},
   title={TetGen, a Delaunay-based quality tetrahedral mesh generator},
   author={Hang, Si},
   journal={ACM Trans. Math. Softw},
@@ -104,6 +114,7 @@
 }
 
 @article{vsprlak2021use,
+  doi={10.1016/j.earscirev.2021.103739},
 	title={On the use of spherical harmonic series inside the minimum Brillouin sphere: Theoretical review and evaluation by GRAIL and LOLA satellite data},
 	author={{\v{S}}prl{\'a}k, Michal and Han, Shin-Chan},
 	journal={Earth-Science Reviews},
@@ -134,6 +145,7 @@
 }
 
 @inproceedings{zhang2010modeling,
+  doi={10.1109/iciecs.2010.5677738},
   title={Modeling and Analysis of Gravity Field of 433Eros Using Polyhedron Model Method},
   author={Zhang, Zhenjiang and Cui, Hutao and Cui, Pingyuan and Yu, Meng},
   booktitle={2010 2nd International Conference on Information Engineering and Computer Science},

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -38,10 +38,10 @@ bibliography: paper.bib
 # Summary
 
 Polyhedral gravity models are essential for modeling the gravitational field of irregular bodies, such as asteroids and comets.
-We present an open-source C++ library for the efficient, parallelized computation of a polyhedral gravity model following the line integral approach by Tsoulis [@tsoulis2012analytical]. A slim, easy-to-use Python interface using *pybind11* accompanies the library. The library is particularly focused on delivering high performance and scalability, which we achieve through vectorization and parallelization with *xsimd* and *thrust*, respectively. For example, the average evaluation of 1 out of 1000 randomly sampled points took 253 microseconds on a M1 Pro chip for the mesh of Eros consisting of 24235 vertices and 14744 faces (see downscaled in \autoref{fig:mesh} [@gaskell2008eros]).
+We present an open-source C++ library for the efficient, parallelized computation of a polyhedral gravity model following the line integral approach by Tsoulis [@tsoulis2012analytical]. A slim, easy-to-use Python interface using *pybind11* accompanies the library. The library is particularly focused on delivering high performance and scalability, which we achieve through vectorization and parallelization with *xsimd* and *thrust*, respectively. For example, the average evaluation of 1 out of 1000 randomly sampled points took 253 microseconds on a M1 Pro chip for the mesh of Eros consisting of 7374 vertices and 14744 faces (see downscaled to 10% in \autoref{fig:mesh} [@gaskell2008eros]).
 The library supports many common formats, such as *.stl*, *.off*, *.ply*, *.mesh* and *tetgen*'s *.node* and *.face* [@hang2015tetgen]. These properties make the application of this implementation straightforward to (re-)use in an arbitrary context.
 
-![Downscaled mesh of (433) Eros to 10% of its original vertices and faces.\label{fig:mesh}](figures/eros.png){ width=50% }
+![Downscaled mesh of (433) Eros to 10% of its original vertices and faces.\label{fig:mesh}](figures/eros_010.png){ width=50% }
 
 # Statement of Need
 


### PR DESCRIPTION
# Changelog

Refers to https://github.com/openjournals/joss-reviews/issues/5978

- add DOIs as requested
- add some URLs for papers without DOI
- fixing a very embarrassing funny error: The paper declared a picture of 67P/Churyumov–Gerasimenko as 433 Eros. Now Eros is actually Eros (also, the number of vertices and faces are now correct)
- Closes #8 by adding a picture of Eros to the `README.md` 


PDF: https://raw.githubusercontent.com/openjournals/joss-papers/joss.05978/joss.05978/10.21105.joss.05978.pdf