### PR TITLE
[JOSS Review] Fix Python syntax of minimal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The simplest way to compute the gravity is to use the `evaluate` function:
 potential, acceleration, tensor = polyhedral_gravity.evaluate(
     polyhedral_source=(cube_vertices, cube_faces),
     density=cube_density,
-    computation_points=computation_point
+    computation_points=computation_point,
     parallel=True
 )
 ```


### PR DESCRIPTION
Fix the Python syntax of the minimal example in the `README.py`. Add a trailing comma to the `computation_points` argument when calling `polyhedral_gravity.evaluate()`.

---

This PR is part of the JOSS review: openjournals/joss-reviews#6384

