### PR TITLE
[JOSS Review] Minor fix to example using GravityEvaluable

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ evaluations. This is especially useful if you want to compute the gravity
 for multiple computation points, but don't know the "future points" in advance.
 
 ```python
-evaluable = model.GravityEvaluable(
+evaluable = polyhedral_gravity.GravityEvaluable(
     polyhedral_source=(cube_vertices, cube_faces),
     density=cube_density
 )


### PR DESCRIPTION
Replace `model.GravityEvaluable` for `polyhedral_gravity.GravityEvaluable` in the minimal Python example showcased in the `README.md`.

---

This PR is part of the JOSS review: openjournals/joss-reviews#6384