### PR TITLE
[JOSS Review] Improve Python tests and unpin Numpy version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,6 @@ name: polyhedral-gravity-env
 channels:
   - conda-forge
 dependencies:
-  - numpy==1.23.4
+  - numpy
   - pytest
   - pytest-xdist

--- a/test/python/test_polyhedral_gravity.py
+++ b/test/python/test_polyhedral_gravity.py
@@ -65,12 +65,10 @@ def test_polyhedral_gravity(
         computation_points=points,
         parallel=True
     )
-    sol = np.array([np.array(x) for x in sol])
-    actual_potential = sol[:, 0].flatten()
-    assert np.testing.assert_array_almost_equal(actual_potential, expected_potential) is None
-
-    actual_acceleration = np.array([np.array(x) for x in sol[:, 1]])
-    assert np.testing.assert_array_almost_equal(actual_acceleration, expected_acceleration) is None
+    potential = np.array([result[0] for result in sol])
+    acceleration = np.array([result[1] for result in sol])
+    np.testing.assert_array_almost_equal(potential, expected_potential)
+    np.testing.assert_array_almost_equal(acceleration, expected_acceleration)
 
 
 @pytest.mark.parametrize(
@@ -92,12 +90,10 @@ def test_polyhedral_gravity_evaluable(
         computation_points=points,
         parallel=True
     )
-    sol = np.array([np.array(x) for x in sol])
-    actual_potential = sol[:, 0].flatten()
-    assert np.testing.assert_array_almost_equal(actual_potential, expected_potential) is None
-
-    actual_acceleration = np.array([np.array(x) for x in sol[:, 1]])
-    assert np.testing.assert_array_almost_equal(actual_acceleration, expected_acceleration) is None
+    potential = np.array([result[0] for result in sol])
+    acceleration = np.array([result[1] for result in sol])
+    np.testing.assert_array_almost_equal(potential, expected_potential)
+    np.testing.assert_array_almost_equal(acceleration, expected_acceleration)
 
 
 @pytest.mark.parametrize(
@@ -128,9 +124,7 @@ def test_polyhedral_evaluable_pickle(
         computation_points=points,
         parallel=True
     )
-    sol = np.array([np.array(x) for x in sol])
-    actual_potential = sol[:, 0].flatten()
-    assert np.testing.assert_array_almost_equal(actual_potential, expected_potential) is None
-
-    actual_acceleration = np.array([np.array(x) for x in sol[:, 1]])
-    assert np.testing.assert_array_almost_equal(actual_acceleration, expected_acceleration) is None
+    potential = np.array([result[0] for result in sol])
+    acceleration = np.array([result[1] for result in sol])
+    np.testing.assert_array_almost_equal(potential, expected_potential)
+    np.testing.assert_array_almost_equal(acceleration, expected_acceleration)


### PR DESCRIPTION
Improve Python tests to work with latest Numpy version. Modify how the potential and acceleration are retrieved from the solution returned by `evaluate()` and `GravityEvaluable` in test functions so they can run with the latest Numpy versions. The previous tests were trying to generate an array from ragged tuples, which is no longer supported by Numpy. Also, modify the `assert np.testing.assert_almost_equal() is None` lines since the Numpy testing functions always return `None`. Unpin Numpy version in `environment.yml` file.

---

@schuhmaj I took some liberties here and made a few changes that I think worth taking a look at. I noticed that the Python tests were only running using the pinned version of Numpy you have in the `environment.yml` file, but not with the latest ones. The reason of this was the lines that try to convert the solutions (a list of tuples) into an array:

https://github.com/esa/polyhedral-gravity-model/blob/ebe47ecb30b946eb9a260702a096fb849611cf4d/test/python/test_polyhedral_gravity.py#L68

 Each element in `sol` is a tuple with the three fields, and each one of them has different number of elements:

- the potential is just a float, 
- the acceleration has three floats,
- the tensor has six floats.

Numpy v1.23.4 is raising a deprecation warning when trying to convert this ragged lists to an array:

```
test/python/test_polyhedral_gravity.py::test_polyhedral_gravity[with_file_input]                        
  /home/santi/git/polyhedral-gravity-model/test/python/test_polyhedral_gravity.py:68: VisibleDeprecation
Warning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-o
r ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'd
type=object' when creating the ndarray.                                                                 
    sol = np.array([np.array(x) for x in sol]) 
```

This means that this line of code won't work with newer Numpy versions (like the latest one, v1.26.4).

The solution I suggest in this PR is to grab the results for the potential and the acceleration for each computation point directly from the `sol` variable (see lines changed in this PR).

I also unpinned Numpy in the `environment.yml` file since tests should run using the latest Numpy version.

Moreover, I modified the `assert` lines. The `numpy.testing.assert...()` functions always return `None`, so asserting if their outputs are None is trivial. Instead it's better to just leave these function calls as they are (see the changed lines in this PR).

Let me know what do you think about this, and feel free to ask any question, and suggest or push changes if you desire to.

---

This PR is part of the JOSS review: openjournals/joss-reviews#6384