### PR TITLE
Switch to GitHubPages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,18 @@
+name: Deploy Sphinx documentation to Pages
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  pages:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - id: deployment
+        uses: sphinx-notes/pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,5 +17,9 @@ jobs:
       pages: write
       id-token: write
     steps:
+      - id: dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen
       - id: deployment
         uses: sphinx-notes/pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ["main"]
 
+env:
+  GITHUB_PAGES_BUILD: True
+
 jobs:
   pages:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # polyhedral-gravity-model
 
-![Build and Test](https://github.com/schuhmaj/polyhedral-gravity-model-cpp/actions/workflows/ctest.yml/badge.svg)
-[![Documentation Status](https://readthedocs.org/projects/polyhedral-gravity-model-cpp/badge/?version=stable)](https://polyhedral-gravity-model-cpp.readthedocs.io/en/stable/?badge=stable)
+![Build and Test](https://github.com/esa/polyhedral-gravity-model/actions/workflows/build-test.yml/badge.svg)
+![Documentation Status](https://github.com/esa/polyhedral-gravity-model/actions/workflows/docs.yml/badge.svg)
 ![GitHub](https://img.shields.io/github/license/esa/polyhedral-gravity-model)
 
 ![PyPI](https://img.shields.io/pypi/v/polyhedral-gravity)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # polyhedral-gravity-model
 
-![Build and Test](https://github.com/esa/polyhedral-gravity-model/actions/workflows/build-test.yml/badge.svg)
-![Documentation Status](https://github.com/esa/polyhedral-gravity-model/actions/workflows/docs.yml/badge.svg)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/esa/polyhedral-gravity-model/.github%2Fworkflows%2Fbuild-and-test.yml?label=Build%20and%20Test)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/esa/polyhedral-gravity-model/.github%2Fworkflows%2Fdocs.yml?logo=GitBook&label=Documentation)
 ![GitHub](https://img.shields.io/github/license/esa/polyhedral-gravity-model)
 
 ![PyPI](https://img.shields.io/pypi/v/polyhedral-gravity)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,26 +30,12 @@ def configure_doxyfile(input_dir, output_dir):
         file.write(filedata)
 
 
-# Check if we're running on Read the Docs' servers
-read_the_docs_build = os.environ.get("READTHEDOCS", None) == "True"
-
 breathe_projects = {}
-if read_the_docs_build:
-    input_dir = "../src"
-    output_dir = "build"
-    configure_doxyfile(input_dir, output_dir)
-    subprocess.call("doxygen", shell=True)
-    breathe_projects["polyhedral-gravity-model"] = output_dir + "/xml"
-
-
-github_pages_build = os.environ.get("GITHUB_PAGES_BUILD", None) == "True"
-
-if github_pages_build:
-    input_dir = "./src"
-    output_dir = "build"
-    configure_doxyfile(input_dir, output_dir)
-    subprocess.call("doxygen", shell=True)
-    breathe_projects["polyhedral-gravity-model"] = output_dir + "/xml"
+input_dir = "../src"
+output_dir = "build"
+configure_doxyfile(input_dir, output_dir)
+subprocess.call("doxygen", shell=True)
+breathe_projects["polyhedral-gravity-model"] = output_dir + "/xml"
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,12 +30,14 @@ def configure_doxyfile(input_dir, output_dir):
         file.write(filedata)
 
 
+# Check if we're running on Read the Docs' servers or in the GitHub Actions Workflow
 breathe_projects = {}
-input_dir = "../src"
-output_dir = "build"
-configure_doxyfile(input_dir, output_dir)
-subprocess.call("doxygen", shell=True)
-breathe_projects["polyhedral-gravity-model"] = output_dir + "/xml"
+if os.environ.get("READTHEDOCS", None) is not None or os.environ.get("GITHUB_PAGES_BUILD", None) is not None:
+    input_dir = "../src"
+    output_dir = "build"
+    configure_doxyfile(input_dir, output_dir)
+    subprocess.call("doxygen", shell=True)
+    breathe_projects["polyhedral-gravity-model"] = output_dir + "/xml"
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,62 +20,96 @@ import subprocess, os
 
 
 def configure_doxyfile(input_dir, output_dir):
-    with open('Doxyfile.in', 'r') as file:
+    with open("Doxyfile.in", "r") as file:
         filedata = file.read()
 
-    filedata = filedata.replace('@DOXYGEN_INPUT_DIR@', input_dir)
-    filedata = filedata.replace('@DOXYGEN_OUTPUT_DIR@', output_dir)
+    filedata = filedata.replace("@DOXYGEN_INPUT_DIR@", input_dir)
+    filedata = filedata.replace("@DOXYGEN_OUTPUT_DIR@", output_dir)
 
-    with open('Doxyfile', 'w') as file:
+    with open("Doxyfile", "w") as file:
         file.write(filedata)
 
 
 # Check if we're running on Read the Docs' servers
-read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
+read_the_docs_build = os.environ.get("READTHEDOCS", None) == "True"
 
 breathe_projects = {}
 if read_the_docs_build:
-    input_dir = '../src'
-    output_dir = 'build'
+    input_dir = "../src"
+    output_dir = "build"
     configure_doxyfile(input_dir, output_dir)
-    subprocess.call('doxygen', shell=True)
-    breathe_projects['polyhedral-gravity-model'] = output_dir + '/xml'
+    subprocess.call("doxygen", shell=True)
+    breathe_projects["polyhedral-gravity-model"] = output_dir + "/xml"
 
 # -- Project information -----------------------------------------------------
 
-project = 'Polyhedral Gravity Model'
-copyright = '2022, Jonas Schuhmacher'
-author = 'Jonas Schuhmacher'
+project = "Polyhedral Gravity Model"
+copyright = "2024, Jonas Schuhmacher"
+author = "Jonas Schuhmacher"
 
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    "breathe"
-]
+extensions = ["breathe"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_book_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Breathe Configuration
 breathe_default_project = "polyhedral-gravity-model"
 breathe_default_members = ("members", "undoc-members")
+
+# -- Options for Theme 'sphinx_book_theme' -----------------------------------
+# https://sphinx-book-theme.readthedocs.io/en/latest/tutorials/get-started.html
+html_theme_options = {
+    "use_edit_page_button": True,
+    "use_source_button": True,
+    "use_issues_button": True,
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/esa/polyhedral-gravity-model",
+            "icon": "fa-brands fa-square-github",
+            "type": "fontawesome",
+        },
+        {
+            "name": "Conda Forge",
+            "url": "https://anaconda.org/conda-forge/polyhedral-gravity-model",
+            "icon": "https://img.shields.io/conda/v/conda-forge/polyhedral-gravity-model",
+            "type": "url",
+        },
+        {
+            "name": "PyPi",
+            "url": "https://pypi.org/project/polyhedral-gravity/",
+            "icon": "https://img.shields.io/pypi/v/polyhedral-gravity",
+            "type": "url",
+        },
+    ],
+}
+
+html_context = {
+    "github_url": "https://github.com",
+    "github_user": "esa",
+    "github_repo": "polyhedral-gravity-model",
+    "github_version": "main",
+    "doc_path": "docs",
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,16 @@ if read_the_docs_build:
     subprocess.call("doxygen", shell=True)
     breathe_projects["polyhedral-gravity-model"] = output_dir + "/xml"
 
+
+github_pages_build = os.environ.get("GITHUB_PAGES_BUILD", None) == "True"
+
+if github_pages_build:
+    input_dir = "./src"
+    output_dir = "build"
+    configure_doxyfile(input_dir, output_dir)
+    subprocess.call("doxygen", shell=True)
+    breathe_projects["polyhedral-gravity-model"] = output_dir + "/xml"
+
 # -- Project information -----------------------------------------------------
 
 project = "Polyhedral Gravity Model"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 breathe
+sphinx-book-theme


### PR DESCRIPTION
# Changelog

## Rational

- The current `ReadTheDocs` setup does not work anymore. The project does not fetch recent information from the ESA repository (somehow stuck, maybe also related to ⬇️)
- Creating the project fresh in `ReadTheDocs` does not work as the `esa` GitHub organization does not have OAuth Access enabled for `ReadTheDocs`.

## Solution

- Switch to GitHub Pages.
The new look: https://schuhmaj.github.io/polyhedral-gravity-model-test/
- This also facilitates the  future "Re-Build," as everything is now directly manageable via GitHub

## TODOs after Merge

- Update `README.md with new links
- Delete `ReadTheDocs` Project
