### PR TITLE
Linux aarch64 Wheels in the CI/CD

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,12 +24,17 @@ jobs:
         ############################# LINUX WHEELS #############################
         # In case of Linux we need to install compiler and build tools before building the wheels
         # We further only build the manylinux wheels, but not the musllinux wheels
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+        if: matrix.os == 'ubuntu-latest'
       - name: Build wheels (Linux)
         uses: pypa/cibuildwheel@v2.17.0
         env:
           CIBW_BEFORE_BUILD: yum makecache && yum install -y gcc-c++ cmake && pip install ninja
           CIBW_BUILD: "*manylinux*"
-          CIBW_ARCHS_LINUX: "auto64"
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
           CIBW_TEST_COMMAND: 'python -c "import polyhedral_gravity"'
         with:
           package-dir: .


### PR DESCRIPTION
# Changelog

- Add some set-up to the wheel-building workflow, which enables building `aarch64` Linux wheels using the `x86_64` based GitHub Linux runner
- For version, `v3.0` I've already locally built and published `aarch64` wheels, so this change comes in handy for future releases
- [Tested inside a fork](https://github.com/schuhmaj/polyhedral-gravity-model-wheel-test/actions/runs/8787927133)