### PR TITLE
Fix Deployment for macOS x86_64 wheels on PyPi

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,7 +23,8 @@ jobs:
       - uses: actions/checkout@v3
         ############################# LINUX WHEELS #############################
         # In case of Linux we need to install compiler and build tools before building the wheels
-        # We further only build the manylinux wheels, but not the musllinux wheels
+        # We only build the manylinux wheels, but not the musllinux wheels (due to some compile problems)
+        # We set-up QEMU to enable aarch64 builds in the GitHub Runner (which is x86_64 based)
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
@@ -41,8 +42,10 @@ jobs:
           output-dir: dist
         if: matrix.os == 'ubuntu-latest'
       ############################# MACOS WHEELS #############################
-      # Building on macOS requires an installation of gcc since the default clang compiler
-      # lacks certain features required for building the package
+      # We use Apple Clang, the macOS GitHub Runner is nowadays arm64 based
+      # The GCC compiler installable via brew does not support cross-compiling for x86_64. Hence, also Apple Claang
+      # For the x86_64, we set the MACOSX_DEPLOYMENT_TARGET='10.13' (released 2017) in order to have support for C++17
+      # We don't need this for the arm64 stuff since it works (and macOS on arm64 cam after C++17)
       - name: Build wheels (macOS ARM)
         uses: pypa/cibuildwheel@v2.17.0
         env:
@@ -56,8 +59,8 @@ jobs:
       - name: Build wheels (macOS x86_64)
         uses: pypa/cibuildwheel@v2.17.0
         env:
-          CIBW_BEFORE_BUILD: brew install ninja gcc@12
-          CIBW_ENVIRONMENT: "CC=gcc-12 CXX=g++-12"
+          CIBW_BEFORE_BUILD: brew install ninja
+          CIBW_ENVIRONMENT: 'MACOSX_DEPLOYMENT_TARGET="10.13"'
           CIBW_ARCHS_MACOS: "x86_64"
           CIBW_TEST_COMMAND: 'python -c "import polyhedral_gravity"'
         with:
@@ -66,6 +69,7 @@ jobs:
         if: matrix.os == 'macos-latest'
       ############################# WINDOWS WHEELS #############################
       # Set up the Visual Studio environment on Windows (required, so that CMake finds the compiler)
+      # We use the Microsoft Visual Studio Compiler to compile the wheel
       - uses: ilammy/msvc-dev-cmd@v1
         if: matrix.os == 'windows-latest'
       - name: Build wheels (Windows)

--- a/README.md
+++ b/README.md
@@ -258,12 +258,12 @@ The project uses the following dependencies,
 all of them are **automatically** set-up via CMake:
 
 - GoogleTest (1.13.0 or compatible), only required for testing
-- spdlog (1.11.0 or compatible), required for logging
+- spdlog (1.13.0 or compatible), required for logging
 - tetgen (1.6 or compatible), required for I/O
-- yaml-cpp (0.7.0 or compatible), required for I/O
+- yaml-cpp (0.8.0 or compatible), required for I/O
 - thrust (2.1.0 or compatible), required for parallelization and utility
 - xsimd (11.1.0 or compatible), required for vectorization of the `atan(..)`
-- pybind11 (2.10.4 or compatible), required for the Python interface, but not the C++ standalone
+- pybind11 (2.12.0 or compatible), required for the Python interface, but not the C++ standalone
 
 The module will be build using a C++17 capable compiler,
 CMake. Just execute the following command in

--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 
 message(STATUS "Setting up pybind11")
 
-find_package(pybind11 2.10.4 QUIET)
+find_package(pybind11 2.12.0 QUIET)
 
 if (${pybind11_FOUND})
 
@@ -12,11 +12,10 @@ else()
 
     message(STATUS "Using pybind11 from git repository")
 
-    #Fetches the version 2.10.4 from the official github of pybind11
     FetchContent_Declare(pybind11
             GIT_REPOSITORY https://github.com/pybind/pybind11
-            GIT_TAG v2.10.4
-            )
+            GIT_TAG v2.12.0
+    )
 
     FetchContent_MakeAvailable(pybind11)
 

--- a/cmake/spdlog.cmake
+++ b/cmake/spdlog.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 
 message(STATUS "Setting up spdlog")
 
-find_package(spdlog 1.14.1 QUIET)
+find_package(spdlog 1.13.0 QUIET)
 
 if (${spdlog_FOUND})
 
@@ -14,7 +14,7 @@ else()
 
     FetchContent_Declare(spdlog
             GIT_REPOSITORY https://github.com/gabime/spdlog.git
-            GIT_TAG v1.14.1
+            GIT_TAG v1.13.0
     )
 
     # Disable stuff we don't need

--- a/cmake/spdlog.cmake
+++ b/cmake/spdlog.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 
 message(STATUS "Setting up spdlog")
 
-find_package(spdlog 1.11.0 QUIET)
+find_package(spdlog 1.14.1 QUIET)
 
 if (${spdlog_FOUND})
 
@@ -12,11 +12,10 @@ else()
 
     message(STATUS "Using spdlog from git repository")
 
-    #Fetches the version 1.11.0 for spdlog
     FetchContent_Declare(spdlog
             GIT_REPOSITORY https://github.com/gabime/spdlog.git
-            GIT_TAG v1.11.0
-            )
+            GIT_TAG v1.14.1
+    )
 
     # Disable stuff we don't need
     option(SPDLOG_BUILD_EXAMPLE "" OFF)

--- a/cmake/tbb.cmake
+++ b/cmake/tbb.cmake
@@ -2,11 +2,11 @@ include(FetchContent)
 
 message(STATUS "Setting up tbb via CMake")
 
-#Fetches the version v2021.5.0 from the official github of tbb
+#Fetches the version v2021.12.0 from the official github of tbb
 FetchContent_Declare(tbb
         GIT_REPOSITORY https://github.com/oneapi-src/oneTBB.git
-        GIT_TAG v2021.5.0
-        )
+        GIT_TAG v2021.12.0
+)
 
 # Disable tests & and do not treat tbb-compile errors as warnings
 option(TBB_TEST "Enable testing" OFF)

--- a/cmake/yaml.cmake
+++ b/cmake/yaml.cmake
@@ -2,7 +2,7 @@ include(FetchContent)
 
 message(STATUS "Setting up yaml-cpp")
 
-find_package(yaml-cpp 0.7.0 QUIET)
+find_package(yaml-cpp 0.8.0 QUIET)
 
 if (${yaml-cpp_FOUND})
 
@@ -10,10 +10,10 @@ if (${yaml-cpp_FOUND})
 
 else()
 
-    #Fetches the version 0.7.0 for yaml-cpp
+    #Fetches the version 0.8.0 for yaml-cpp
     FetchContent_Declare(yaml-cpp
             GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-            GIT_TAG yaml-cpp-0.7.0
+            GIT_TAG 0.8.0
             )
 
     # Disable everything we don't need

--- a/docs/background/mesh_integrity.rst
+++ b/docs/background/mesh_integrity.rst
@@ -54,13 +54,13 @@ The :code:`Polyhedron` class checks the pointing direction of every single
 normal. This way, the `Polyhedron` ensures correct results even if a mistake occurs during the definition.
 
 Since we are in 3D and might have concave and convex polyhedrons,
-the viable option is the `Möller–Trumbore intersection algorithm <https://en.wikipedia.org/wiki/Möller–Trumbore_intersection_algorithm>`__.
-It checks the amount of intersections the plane unit normal has with the polyhedron.
-If its an even number, the normals is :code:`OUTWARDS` pointing, otherwise :code:`INWARDS`.
+the most viable option is the `Möller–Trumbore intersection algorithm <https://en.wikipedia.org/wiki/Möller–Trumbore_intersection_algorithm>`__.
+It checks the amount of intersections each plane unit normal has with the polyhedron.
+If this is an even number, the normal is :code:`OUTWARDS` pointing, otherwise :code:`INWARDS`.
 In the *current implementation*, we implement a naiv version
 which takes :math:`O(n^2)` operations - which can get quite expensive for polyhedrons with many faces.
 
-To make this as straightforward to use as possible, we provide four options
+To make this as straightforward to use, we provide four options
 for the construction of a polyhedron in the form of the enum :code:`PolyhedronIntegrity`:
 
 +-----------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------+----------------+

--- a/docs/quickstart/installation.rst
+++ b/docs/quickstart/installation.rst
@@ -105,10 +105,10 @@ Dependencies (automatically set-up)
 Dependencies (all of them are automatically set-up via :code:`CMake`):
 
 - GoogleTest (1.13.0 or compatible), only required for testing
-- spdlog (1.11.0 or compatible), required for logging
+- spdlog (1.13.0 or compatible), required for logging
 - tetgen (1.6 or compatible), required for I/O
-- yaml-cpp (0.7.0 or compatible), required for I/O
+- yaml-cpp (0.8.0 or compatible), required for I/O
 - thrust (2.1.0 or compatible), required for parallelization and utility
 - xsimd (11.1.0 or compatible), required for vectorization of the :code:`atan(..)`
-- pybind11 (2.10.4 or compatible), required for the Python interface, but not the C++ standalone
+- pybind11 (2.12.0 or compatible), required for the Python interface, but not the C++ standalone
 

--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,7 @@ picture_in_readme = '''<p align="center">
 # --------------------------------------------------------------------------------
 setup(
     name="polyhedral_gravity",
-    version="3.2rc1",
+    version="3.2",
     author="Jonas Schuhmacher",
     author_email="jonas.schuhmacher@tum.de",
     description="Package to compute full gravity tensor of a given constant density polyhedron for arbitrary points "

--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,7 @@ picture_in_readme = '''<p align="center">
 # --------------------------------------------------------------------------------
 setup(
     name="polyhedral_gravity",
-    version="3.1",
+    version="3.2rc1",
     author="Jonas Schuhmacher",
     author_email="jonas.schuhmacher@tum.de",
     description="Package to compute full gravity tensor of a given constant density polyhedron for arbitrary points "


### PR DESCRIPTION
# Changelog

STATUS RELEASE CANDIDATE 3.2rc1
[![Build & Publish Python Package](https://github.com/esa/polyhedral-gravity-model/actions/workflows/wheels.yml/badge.svg?branch=fix-macos-x86)](https://github.com/esa/polyhedral-gravity-model/actions/workflows/wheels.yml)

The macOS x86_64 wheel deployment also broke. It seems that the runner is now using the `arm64` architecture.
The current set-up using `gcc` is no longer applicable as it does not allow cross-compiling. Hence, we need to use Apple Clang, as in the `arm64` based approach.

Our dependency TBB requires C++17. Hence, the minimal deployment target for macOS x86_64 is now `macOS 10.13`, released in 2017, from which point Apple Clang and friends support C++17. The support for older versions is dropped (previously, the target was `10.9`) - at least for releases on `PyPi`, `conda` will still build for `10.9` and newer (since it uses OpenMP for parallelization and omits the TBB dependency).

### Minor stuff along the way

- Spelling and Grammar in the Docs (because one always finds some mistakes 🙃)
- Bump up dependencies versions (pybind11, spdlog, yaml-cpp, TBB)
- Increment version to `3.2` so that the JOSS release has a round number

_Uff, I never release again, thinking no code changes will lead to smooth deployment... the CI/ CD environment could also change, as it happened_