### PR TITLE
# JOSS References for README and Documentation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,50 @@
+cff-version: "1.2.0"
+authors:
+- family-names: Schuhmacher
+  given-names: Jonas
+  orcid: "https://orcid.org/0009-0005-9693-4530"
+- family-names: Blazquez
+  given-names: Emmanuel
+  orcid: "https://orcid.org/0000-0001-9697-582X"
+- family-names: Gratl
+  given-names: Fabio
+  orcid: "https://orcid.org/0000-0001-5195-7919"
+- family-names: Izzo
+  given-names: Dario
+  orcid: "https://orcid.org/0000-0002-9846-8423"
+- family-names: Gómez
+  given-names: Pablo
+  orcid: "https://orcid.org/0000-0002-5631-8240"
+doi: 10.5281/zenodo.11221939
+message: If you use this software, please cite our article in the
+  Journal of Open Source Software.
+preferred-citation:
+  authors:
+  - family-names: Schuhmacher
+    given-names: Jonas
+    orcid: "https://orcid.org/0009-0005-9693-4530"
+  - family-names: Blazquez
+    given-names: Emmanuel
+    orcid: "https://orcid.org/0000-0001-9697-582X"
+  - family-names: Gratl
+    given-names: Fabio
+    orcid: "https://orcid.org/0000-0001-5195-7919"
+  - family-names: Izzo
+    given-names: Dario
+    orcid: "https://orcid.org/0000-0002-9846-8423"
+  - family-names: Gómez
+    given-names: Pablo
+    orcid: "https://orcid.org/0000-0002-5631-8240"
+  date-published: 2024-06-01
+  doi: 10.21105/joss.06384
+  issn: 2475-9066
+  issue: 98
+  journal: Journal of Open Source Software
+  publisher:
+    name: Open Journals
+  start: 6384
+  title: Efficient Polyhedral Gravity Modeling in Modern C++ and Python
+  type: article
+  url: "https://joss.theoj.org/papers/10.21105/joss.06384"
+  volume: 9
+title: Efficient Polyhedral Gravity Modeling in Modern C++ and Python

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # polyhedral-gravity-model
 
+[![DOI](https://joss.theoj.org/papers/10.21105/joss.06384/status.svg)](https://doi.org/10.21105/joss.06384)
+![GitHub](https://img.shields.io/github/license/esa/polyhedral-gravity-model)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/esa/polyhedral-gravity-model/.github%2Fworkflows%2Fbuild-and-test.yml?logo=GitHub%20Actions&label=Build%20and%20Test)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/esa/polyhedral-gravity-model/.github%2Fworkflows%2Fdocs.yml?logo=GitBook&label=Documentation)
-![GitHub](https://img.shields.io/github/license/esa/polyhedral-gravity-model)
 
 ![PyPI](https://img.shields.io/pypi/v/polyhedral-gravity)
 ![Static Badge](https://img.shields.io/badge/platform-linux--64_%7C_win--64_%7C_osx--64_%7C_linux--arm64_%7C_osx--arm64-lightgrey)

--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@
 ## References
 
 This code is a validated implementation in C++17 of the Polyhedral Gravity Model
-by Tsoulis et al.. It was created in a collaborative project between
-TU Munich and ESA's Advanced Concepts Team. Please refer to the
-[project report](https://mediatum.ub.tum.de/doc/1695208/1695208.pdf)
-for extensive information about the theoretical background, related work,
-implementation & design decisions, application, verification,
-and runtime measurements of the presented code.
+by Tsoulis et al.. Additionally, the model provides a Python binding.
+It was initially created in a collaborative project between
+TU Munich and ESA's Advanced Concepts Team.
+
+If this implementation proves useful to you, please consider citing the 
+[accompanying paper](https://doi.org/10.21105/joss.06384)
+published in the *Journal of Open Source Software*.
 
 The implementation is based on the
 paper [Tsoulis, D., 2012. Analytical computation of the full gravity tensor of a homogeneous arbitrarily shaped polyhedral source using line integrals. Geophysics, 77(2), pp.F1-F11.](http://dx.doi.org/10.1190/geo2010-0334.1)

--- a/docs/background/approach.rst
+++ b/docs/background/approach.rst
@@ -3,21 +3,25 @@ Implementation's Details
 
 
 This code is a validated implementation in C++17 of the Polyhedral Gravity Model
-by Tsoulis et al.. It was created in a collaborative project between
-TU Munich and ESA's Advanced Concepts Team. Please refer to the
-`project report <https://mediatum.ub.tum.de/doc/1695208/1695208.pdf>`__
-for extensive information about the theoretical background, related work,
-implementation & design decisions, application, verification,
-and runtime measurements of the presented code.
+by Tsoulis et al.. Additionally, the model provides a Python binding.
+It was initially created in a collaborative project between
+TU Munich and ESA's Advanced Concepts Team.
 
-The implementation is based on the
-paper `Tsoulis, D., 2012. Analytical computation of the full gravity tensor of a homogeneous arbitrarily shaped polyhedral source using line integrals. Geophysics, 77(2), pp.F1-F11. <http://dx.doi.org/10.1190/geo2010-0334.1>`__
-and its corresponding implementation in FORTRAN_ (last accessed: 12.09.2022).
+If this implementation proves useful to you, please consider citing the
+`accompanying paper <https://doi.org/10.21105/joss.06384>`__
+published in the *Journal of Open Source Software*.
+It summarizes application scenarios, related work and the architectural design since version :code:`3.0`.
 
-Supplementary details can be found in the more recent
-paper `TSOULIS, Dimitrios; GAVRIILIDOU, Georgia. A computational review of the line integral analytical formulation of the polyhedral gravity signal. Geophysical Prospecting, 2021, 69. Jg., Nr. 8-9, S. 1745-1760 <https://doi.org/10.1111/1365-2478.13134>`__
-and its corresponding implementation in MATLAB_ (last accessed: 28.03.2024),
-which is strongly based on the former implementation in FORTRAN.
+For a detailed dive into the theoretical background, consult the
+`initial project report <https://mediatum.ub.tum.de/doc/1695208/1695208.pdf>`__.
+While theoretical background, core implementation, verification and results are still valid. The implementation's
+interface changed over the course of the time. The initial project report refers to version :code:`1.2.1`.
+Hence, its usage examples will not work with the current version!
+
+Further, the approach is documented by Tsoulis et al. in the following two major publications:
+
+- `Tsoulis, D., 2012. Analytical computation of the full gravity tensor of a homogeneous arbitrarily shaped polyhedral source using line integrals. Geophysics, 77(2), pp.F1-F11. <http://dx.doi.org/10.1190/geo2010-0334.1>`__ and its corresponding implementation in FORTRAN_ (last accessed: 12.09.2022).
+- `TSOULIS, Dimitrios; GAVRIILIDOU, Georgia. A computational review of the line integral analytical formulation of the polyhedral gravity signal. Geophysical Prospecting, 2021, 69. Jg., Nr. 8-9, S. 1745-1760 <https://doi.org/10.1111/1365-2478.13134>`__ and its corresponding implementation in MATLAB_ (last accessed: 28.03.2024), which is strongly based on the former implementation in FORTRAN.
 
 
 

--- a/docs/background/approach.rst
+++ b/docs/background/approach.rst
@@ -14,8 +14,9 @@ It summarizes application scenarios, related work and the architectural design s
 
 For a detailed dive into the theoretical background, consult the
 `initial project report <https://mediatum.ub.tum.de/doc/1695208/1695208.pdf>`__.
-While theoretical background, core implementation, verification and results are still valid. The implementation's
-interface changed over the course of the time. The initial project report refers to version :code:`1.2.1`.
+Its content about the theoretical background, core implementation, verification, and results is still valid.
+However, the implementation's public interfaces changed over time.
+The initial project report refers to version :code:`1.2.1`.
 Hence, its usage examples will not work with the current version!
 
 Further, the approach is documented by Tsoulis et al. in the following two major publications:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,10 @@ get into the use of the polyhedral gravity model.
 
 And for more details, refer to the **Python API** or **C++ API**.
 
+If this implementation proves useful to you, please consider citing the
+`accompanying paper <https://doi.org/10.21105/joss.06384>`__
+published in the *Journal of Open Source Software*.
+
 .. toctree::
    :caption: INSTALLATION & QUICK START
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,7 +41,22 @@ And for more details, refer to the **Python API** or **C++ API**.
 
 If this implementation proves useful to you, please consider citing the
 `accompanying paper <https://doi.org/10.21105/joss.06384>`__
-published in the *Journal of Open Source Software*.
+published in the *Journal of Open Source Software*:
+
+.. code-block:: bibtex
+
+   @article{Schuhmacher_Efficient_Polyhedral_Gravity_2024,
+      author = {Schuhmacher, Jonas and Blazquez, Emmanuel and Gratl, Fabio and Izzo, Dario and Gómez, Pablo},
+      doi = {10.21105/joss.06384},
+      journal = {Journal of Open Source Software},
+      month = jun,
+      number = {98},
+      pages = {6384},
+      title = {{Efficient Polyhedral Gravity Modeling in Modern C++ and Python}},
+      url = {https://joss.theoj.org/papers/10.21105/joss.06384},
+      volume = {9},
+      year = {2024}
+   }
 
 .. toctree::
    :caption: INSTALLATION & QUICK START

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,12 +6,14 @@
 Welcome to Polyhedral Gravity Model's documentation!
 ====================================================
 
+.. image:: https://joss.theoj.org/papers/10.21105/joss.06384/status.svg
+   :target: https://doi.org/10.21105/joss.06384
+.. image:: https://img.shields.io/github/license/esa/polyhedral-gravity-model
+   :alt: GitHub License
 .. image:: https://img.shields.io/github/actions/workflow/status/esa/polyhedral-gravity-model/.github%2Fworkflows%2Fbuild-and-test.yml?logo=GitHub%20Actions&label=Build%20and%20Test
    :alt: GitHub Actions Workflow Status
 .. image:: https://img.shields.io/github/actions/workflow/status/esa/polyhedral-gravity-model/.github%2Fworkflows%2Fdocs.yml?logo=gitbook&label=Documentation
    :alt: GitHub Actions Workflow Status
-.. image:: https://img.shields.io/github/license/esa/polyhedral-gravity-model
-   :alt: GitHub License
 
 ..
 


### PR DESCRIPTION
# Changelog - JOSS References 🎉

🥳 Our paper has been accepted and published! https://github.com/openjournals/joss-reviews/issues/6384

- Add the `CITATION.cff` file as suggested
- Add the JOSS badge to `README.md` and documentation front page as suggested
- Add `bibtex` entry to the documentation
- Remove the reference to the *initial project report* from the `README.md` (since it refers to version `1.2.1`) and replace it with the JOSS paper
  - This way, we have no confusion with the JOSS paper and focus on the gist in the `README.md`, which is up-to-date 
  - `docs/background/approach.rst` still documents and links the interdisciplinary project report but states that its usage examples are outdated