### PR TITLE
Python 3.13 Wheels/ Release 3.2.1

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,7 +31,7 @@ jobs:
           platforms: all
         if: matrix.os == 'ubuntu-latest'
       - name: Build wheels (Linux)
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_BEFORE_BUILD: yum makecache && yum install -y gcc-c++ cmake && pip install ninja
           CIBW_BUILD: "*manylinux*"
@@ -47,7 +47,7 @@ jobs:
       # For the x86_64, we set the MACOSX_DEPLOYMENT_TARGET='10.13' (released 2017) in order to have support for C++17
       # We don't need this for the arm64 stuff since it works (and macOS on arm64 cam after C++17)
       - name: Build wheels (macOS ARM)
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_BEFORE_BUILD: brew install ninja
           CIBW_ARCHS_MACOS: "arm64"
@@ -57,7 +57,7 @@ jobs:
           output-dir: dist
         if: matrix.os == 'macos-latest'
       - name: Build wheels (macOS x86_64)
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_BEFORE_BUILD: brew install ninja
           CIBW_ENVIRONMENT: 'MACOSX_DEPLOYMENT_TARGET="10.13"'
@@ -73,7 +73,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
         if: matrix.os == 'windows-latest'
       - name: Build wheels (Windows)
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_BEFORE_BUILD: choco install -y ninja cmake
           CIBW_ARCHS_WINDOWS: "auto64"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -67,7 +67,6 @@ jobs:
         uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_BEFORE_BUILD: pipx install ninja cmake
-          CIBW_FREE_THREADED_SUPPORT: 1
           CIBW_ARCHS_WINDOWS: "auto64"
           CIBW_TEST_COMMAND: 'python -c "import polyhedral_gravity"'
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,7 +46,7 @@ jobs:
       # The GCC compiler installable via brew does not support cross-compiling for x86_64. Hence, also Apple Claang
       # For the x86_64, we set the MACOSX_DEPLOYMENT_TARGET='10.13' (released 2017) in order to have support for C++17
       # We don't need this for the arm64 stuff since it works (and macOS on arm64 cam after C++17)
-      - name: Build wheels (macOS x86_64)
+      - name: Build wheels (macOS)
         uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_BEFORE_BUILD: pipx install ninja cmake

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Build wheels (Linux)
         uses: pypa/cibuildwheel@v2.20.0
         env:
-          CIBW_BEFORE_BUILD: yum makecache && yum install -y gcc-c++ cmake && pip install ninja
-          CIBW_BUILD: "*manylinux*"
+          CIBW_BEFORE_BUILD: pipx install ninja cmake
+          CIBW_FREE_THREADED_SUPPORT: 1
           CIBW_ARCHS_LINUX: "x86_64 aarch64"
           CIBW_TEST_COMMAND: 'python -c "import polyhedral_gravity"'
         with:
@@ -46,22 +46,13 @@ jobs:
       # The GCC compiler installable via brew does not support cross-compiling for x86_64. Hence, also Apple Claang
       # For the x86_64, we set the MACOSX_DEPLOYMENT_TARGET='10.13' (released 2017) in order to have support for C++17
       # We don't need this for the arm64 stuff since it works (and macOS on arm64 cam after C++17)
-      - name: Build wheels (macOS ARM)
-        uses: pypa/cibuildwheel@v2.20.0
-        env:
-          CIBW_BEFORE_BUILD: brew install ninja
-          CIBW_ARCHS_MACOS: "arm64"
-          CIBW_TEST_COMMAND: 'python -c "import polyhedral_gravity"'
-        with:
-          package-dir: .
-          output-dir: dist
-        if: matrix.os == 'macos-latest'
       - name: Build wheels (macOS x86_64)
         uses: pypa/cibuildwheel@v2.20.0
         env:
-          CIBW_BEFORE_BUILD: brew install ninja
+          CIBW_BEFORE_BUILD: pipx install ninja cmake
+          CIBW_FREE_THREADED_SUPPORT: 1
           CIBW_ENVIRONMENT: 'MACOSX_DEPLOYMENT_TARGET="10.13"'
-          CIBW_ARCHS_MACOS: "x86_64"
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_TEST_COMMAND: 'python -c "import polyhedral_gravity"'
         with:
           package-dir: .
@@ -75,7 +66,8 @@ jobs:
       - name: Build wheels (Windows)
         uses: pypa/cibuildwheel@v2.20.0
         env:
-          CIBW_BEFORE_BUILD: choco install -y ninja cmake
+          CIBW_BEFORE_BUILD: pipx install ninja cmake
+          CIBW_FREE_THREADED_SUPPORT: 1
           CIBW_ARCHS_WINDOWS: "auto64"
           CIBW_TEST_COMMAND: 'python -c "import polyhedral_gravity"'
         with:
@@ -98,38 +90,38 @@ jobs:
         with:
           path: dist/*.tar.gz
 
-  # 2. Upload the wheels and the source distribution to testpypi
-  #    using trusted publishing
-  upload_testpypi:
-    needs: [build_wheels, make_sdist]
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/polyhedral-gravity
-    permissions:
-      id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-
-  # 3. Upload the wheels to the actually Python Package Index
-  #    using trusted publishing
-  upload_pypi:
-    needs: [build_wheels, make_sdist, upload_testpypi]
-    environment:
-      name: pypi
-      url: https://pypi.org/p/polyhedral-gravity
-    permissions:
-      id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+#  # 2. Upload the wheels and the source distribution to testpypi
+#  #    using trusted publishing
+#  upload_testpypi:
+#    needs: [build_wheels, make_sdist]
+#    environment:
+#      name: testpypi
+#      url: https://test.pypi.org/p/polyhedral-gravity
+#    permissions:
+#      id-token: write
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/download-artifact@v3
+#        with:
+#          name: artifact
+#          path: dist
+#      - uses: pypa/gh-action-pypi-publish@release/v1
+#        with:
+#          repository-url: https://test.pypi.org/legacy/
+#
+#  # 3. Upload the wheels to the actually Python Package Index
+#  #    using trusted publishing
+#  upload_pypi:
+#    needs: [build_wheels, make_sdist, upload_testpypi]
+#    environment:
+#      name: pypi
+#      url: https://pypi.org/p/polyhedral-gravity
+#    permissions:
+#      id-token: write
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/download-artifact@v3
+#        with:
+#          name: artifact
+#          path: dist
+#      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/checkout@v3
         ############################# LINUX WHEELS #############################
         # In case of Linux we need to install compiler and build tools before building the wheels
-        # We only build the manylinux wheels, but not the musllinux wheels (due to some compile problems)
         # We set-up QEMU to enable aarch64 builds in the GitHub Runner (which is x86_64 based)
+        # We build wheels for manylinux and musllinux for aarch64 and x86_64
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
@@ -42,10 +42,10 @@ jobs:
           output-dir: dist
         if: matrix.os == 'ubuntu-latest'
       ############################# MACOS WHEELS #############################
-      # We use Apple Clang, the macOS GitHub Runner is nowadays arm64 based
-      # The GCC compiler installable via brew does not support cross-compiling for x86_64. Hence, also Apple Claang
+      # We use Apple Clang as it is the only compiler offering cross-compiling for x86_64
+      # The macOS GitHub Runner is nowadays arm64 based
       # For the x86_64, we set the MACOSX_DEPLOYMENT_TARGET='10.13' (released 2017) in order to have support for C++17
-      # We don't need this for the arm64 stuff since it works (and macOS on arm64 cam after C++17)
+      # We don't need this for arm64 since macOS arm64 initially supported C++17/ came years later than macOS 10.13
       - name: Build wheels (macOS)
         uses: pypa/cibuildwheel@v2.20.0
         env:
@@ -61,6 +61,7 @@ jobs:
       ############################# WINDOWS WHEELS #############################
       # Set up the Visual Studio environment on Windows (required, so that CMake finds the compiler)
       # We use the Microsoft Visual Studio Compiler to compile the wheel
+      # As of 09.09.2024, it is not yet possible to build free-threaded wheel on Windows
       - uses: ilammy/msvc-dev-cmd@v1
         if: matrix.os == 'windows-latest'
       - name: Build wheels (Windows)
@@ -89,38 +90,38 @@ jobs:
         with:
           path: dist/*.tar.gz
 
-#  # 2. Upload the wheels and the source distribution to testpypi
-#  #    using trusted publishing
-#  upload_testpypi:
-#    needs: [build_wheels, make_sdist]
-#    environment:
-#      name: testpypi
-#      url: https://test.pypi.org/p/polyhedral-gravity
-#    permissions:
-#      id-token: write
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/download-artifact@v3
-#        with:
-#          name: artifact
-#          path: dist
-#      - uses: pypa/gh-action-pypi-publish@release/v1
-#        with:
-#          repository-url: https://test.pypi.org/legacy/
-#
-#  # 3. Upload the wheels to the actually Python Package Index
-#  #    using trusted publishing
-#  upload_pypi:
-#    needs: [build_wheels, make_sdist, upload_testpypi]
-#    environment:
-#      name: pypi
-#      url: https://pypi.org/p/polyhedral-gravity
-#    permissions:
-#      id-token: write
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/download-artifact@v3
-#        with:
-#          name: artifact
-#          path: dist
-#      - uses: pypa/gh-action-pypi-publish@release/v1
+  # 2. Upload the wheels and the source distribution to testpypi
+  #    using trusted publishing
+  upload_testpypi:
+    needs: [build_wheels, make_sdist]
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/polyhedral-gravity
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  # 3. Upload the wheels to the actually Python Package Index
+  #    using trusted publishing
+  upload_pypi:
+    needs: [build_wheels, make_sdist, upload_testpypi]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/polyhedral-gravity
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,16 @@ option(USE_LOCAL_TBB "Uses the local tbb installation rather than on using the a
 GitHub via CMake (Default: OFF)" OFF)
 
 # Set the Logging Level
-set(LOGGING_LEVEL "2" CACHE STRING "Set the Logging level, default (INFO=2), available options:
-TRACE=0, DEBUG=1, INFO=2, WARN=3, ERROR=4, CRITICAL=5, OFF=6")
-set_property(CACHE LOGGING_LEVEL PROPERTY STRINGS 0, 1, 2, 3, 4, 5, 6)
-add_compile_definitions(SPDLOG_ACTIVE_LEVEL=${LOGGING_LEVEL})
+set(LOGGING_LEVEL_LIST "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "CRITICAL" "OFF")
+set(LOGGING_LEVEL "INFO" CACHE STRING "Set the Logging level, default (INFO), available options: TRACE, DEBUG, INFO, WARN, ERROR, CRITICAL, OFF")
+set_property(CACHE LOGGING_LEVEL PROPERTY STRINGS ${LOGGING_LEVEL_LIST})
+# Convert the logging level string to its corresponding number
+list(FIND LOGGING_LEVEL_LIST ${LOGGING_LEVEL} LOGGING_LEVEL_INDEX)
+if (${LOGGING_LEVEL_INDEX} EQUAL -1)
+    message(FATAL_ERROR "Invalid logging level: ${LOGGING_LEVEL}")
+endif ()
+add_compile_definitions(SPDLOG_ACTIVE_LEVEL=${LOGGING_LEVEL_INDEX})
+message(STATUS "Logging level set to ${LOGGING_LEVEL} (=${LOGGING_LEVEL_INDEX})")
 
 ###################################
 # What actually to build? - Options

--- a/README.md
+++ b/README.md
@@ -305,14 +305,14 @@ cmake --build .
 
 The following options are available:
 
-|                             Name (Default) | Options                                                                                    |
-|-------------------------------------------:|:-------------------------------------------------------------------------------------------|
-| POLYHEDRAL_GRAVITY_PARALLELIZATION (`CPP`) | `CPP` = Serial Execution / `OMP` or `TBB` = Parallel Execution with OpenMP or Intel\'s TBB |
-|                        LOGGING_LEVEL (`2`) | `0` = TRACE/ `1` = DEBUG/ `2` = INFO / `3` = WARN/ `4` = ERROR/ `5` = CRITICAL/ `6` = OFF  |
-|                      USE_LOCAL_TBB (`OFF`) | Use a local installation of `TBB` instead of setting it up via `CMake`                     |
-|      BUILD_POLYHEDRAL_GRAVITY_DOCS (`OFF`) | Build this documentation                                                                   |
-|      BUILD_POLYHEDRAL_GRAVITY_TESTS (`ON`) | Build the Tests                                                                            |
-|   BUILD_POLYHEDRAL_PYTHON_INTERFACE (`ON`) | Build the Python interface                                                                 |
+|                             Name (Default) | Options                                                                                     |
+|-------------------------------------------:|:--------------------------------------------------------------------------------------------|
+| POLYHEDRAL_GRAVITY_PARALLELIZATION (`CPP`) | `CPP` = Serial Execution / `OMP` or `TBB` = Parallel Execution with OpenMP or Intel\'s TBB  |
+|                     LOGGING_LEVEL (`INFO`) | `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`, `OFF`                                |
+|                      USE_LOCAL_TBB (`OFF`) | Use a local installation of `TBB` instead of setting it up via `CMake`                      |
+|      BUILD_POLYHEDRAL_GRAVITY_DOCS (`OFF`) | Build this documentation                                                                    |
+|      BUILD_POLYHEDRAL_GRAVITY_TESTS (`ON`) | Build the Tests                                                                             |
+|   BUILD_POLYHEDRAL_PYTHON_INTERFACE (`ON`) | Build the Python interface                                                                  |
 
 During testing POLYHEDRAL_GRAVITY_PARALLELIZATION=`TBB` has been the most performant.
 It is further not recommend to change the LOGGING_LEVEL to something else than `INFO=2`.

--- a/docs/quickstart/installation.rst
+++ b/docs/quickstart/installation.rst
@@ -91,7 +91,7 @@ The available options are the following:
 Name (Default)                                   Options
 ================================================ ===================================================================================================================================
 POLYHEDRAL_GRAVITY_PARALLELIZATION (:code:`CPP`) :code:`CPP` = Serial Execution / :code:`OMP` or :code:`TBB`  = Parallel Execution with OpenMP or Intel's TBB
-LOGGING_LEVEL (:code:`2`)                        :code:`0` = TRACE/ :code:`1` = DEBUG/ :code:`2` = INFO / :code:`3` = WARN/ :code:`4` = ERROR/ :code:`5` = CRITICAL/ :code:`6` = OFF
+LOGGING_LEVEL (:code:`INFO`)                     :code:`TRACE`, :code:`DEBUG`, :code:`INFO`, :code:`WARN`, :code:`ERROR`, :code:`CRITICAL`, :code:`OFF`
 USE_LOCAL_TBB (:code:`OFF`)                      Use a local installation of :code:`TBB` instead of setting it up via :code:`CMake`
 BUILD_POLYHEDRAL_GRAVITY_DOCS (:code:`OFF`)      Build this documentation
 BUILD_POLYHEDRAL_GRAVITY_TESTS (:code:`ON`)      Build the Tests

--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,7 @@ picture_in_readme = '''<p align="center">
 # --------------------------------------------------------------------------------
 setup(
     name="polyhedral_gravity",
-    version="3.2.1rc1",
+    version="3.2.1",
     author="Jonas Schuhmacher",
     author_email="jonas.schuhmacher@tum.de",
     description="Package to compute full gravity tensor of a given constant density polyhedron for arbitrary points "

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ CMAKE_OPTIONS = {
     # Modify to change the parallelization (Default value: TBB)
     "POLYHEDRAL_GRAVITY_PARALLELIZATION": "TBB",
     # Default value (INFO=2)
-    "LOGGING_LEVEL": 2,
+    "LOGGING_LEVEL": "INFO",
     # Default value (OFF)
     "USE_LOCAL_TBB": "OFF",
     # Not required for the python interface (--> OFF)

--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,7 @@ picture_in_readme = '''<p align="center">
 # --------------------------------------------------------------------------------
 setup(
     name="polyhedral_gravity",
-    version="3.2",
+    version="3.2.1rc1",
     author="Jonas Schuhmacher",
     author_email="jonas.schuhmacher@tum.de",
     description="Package to compute full gravity tensor of a given constant density polyhedron for arbitrary points "


### PR DESCRIPTION
# Changelog: Python 3.13 Support 🥳

This PR adapts the PyPi release toolchain to publish wheels for

[![Build & Publish Python Package](https://github.com/esa/polyhedral-gravity-model/actions/workflows/wheels.yml/badge.svg?branch=python-313-fix)](https://github.com/esa/polyhedral-gravity-model/actions/workflows/wheels.yml)

Release Candidate available:

```bash
pip install polyhedral-gravity==3.2.1rc1
```

- Build wheels for Python 3.13 by bumping `cibuildhweel` to version `2.20`
- Build wheels for free-threaded/ GIL-free Python (not yet on Windows)
- Build wheels for `musllinux` (Docker Images changed, we don't have any problem anymore. We now are **truly** supporting **everything**)
- Simplify CI/CD script by simply using `pipx` for dependencies and merging macOS `arm64`and `x86_64` workflows
- Increment Version Number to `3.2.1` marking the official Python 3.13 support start on PyPi (conda-forge version for Python 3.13 is already released)
- Small improvement: The. `LOGGING_LEVEL` when building the C++ solution is now set using **natural language**, so, e.g., `-DLOGGING_LEVEL=INFO` instead of `-DLOGGING_LEVEL=2`