### PR TITLE
Modernize CMake Fetching & Update Mamba CI/ CD

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,14 +46,17 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
         if: matrix.os == 'windows-latest'
       - name: Install Conda environment from environment.yml
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: '1.5.6-0'
           environment-file: environment.yml
           cache-downloads: true
-          cache-env: true
+          cache-environment: true
+          init-shell: bash powershell
       - name: Install & Test polyhedral-gravity
-        shell: bash -l {0}
         run: |
           pip install . -vv --no-build-isolation
           pytest -n 3
+        shell: bash -el {0}
+
           

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,6 @@ set(POLYHEDRAL_GRAVITY_PARALLELIZATION "CPP" CACHE STRING "Host parallelization 
  (CPP= Serial, OMP = OpenMP, TBB = Intel Threading Building Blocks")
 set_property(CACHE POLYHEDRAL_GRAVITY_PARALLELIZATION PROPERTY STRINGS CPP, OMP, TBB)
 
-# Enforce to use an already installed tbb library instead of compiling from source
-option(USE_LOCAL_TBB "Uses the local tbb installation rather than on using the automatically fetched version from
-GitHub via CMake (Default: OFF)" OFF)
-
 # Set the Logging Level
 set(LOGGING_LEVEL_LIST "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "CRITICAL" "OFF")
 set(LOGGING_LEVEL "INFO" CACHE STRING "Set the Logging level, default (INFO), available options: TRACE, DEBUG, INFO, WARN, ERROR, CRITICAL, OFF")
@@ -77,9 +73,9 @@ include(clang_format)
 # Get a version of tbb from the github repository, simplifies compilation for the user since tbb does not need to be
 # preinstalled but rather gets automatically set up via CMake
 # Nevertheless, there is still the option to enforce to use a local installation if one exists
-if (NOT USE_LOCAL_TBB AND ${POLYHEDRAL_GRAVITY_PARALLELIZATION} STREQUAL "TBB")
+if (${POLYHEDRAL_GRAVITY_PARALLELIZATION} STREQUAL "TBB")
     include(tbb)
-    thrust_set_TBB_target(tbb)
+    thrust_set_TBB_target(TBB::tbb)
 endif ()
 
 # Thrust set-up i.e. the parallelization library, create targets according to the users specification

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ include(thrust)
 include(spdlog)
 include(tetgen)
 include(xsimd)
+include(clang_format)
 
 ###############################
 # Thrust Parallelization Set-Up

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,10 @@ Have you found an issue you would like to work on? Or do you have a great idea f
 
 - Ensure that you work on a new branch for your contribution. The name does not need to follow a specific pattern, but it should be descriptive (e.g. `fix-issue-123` or `fancy-feature-xyz`).
 - Make sure that you are using the latest version from `main`. Instructions on how to set up the project can be found in the [documentation](https://esa.github.io/polyhedral-gravity-model/) or in the [README](README.md).
-- Please try to follow the existing code style and conventions.
+- Please try to follow the existing code style and conventions. You can apply our clang-format via CMake by executing in the build-folder:
+  ```bash
+  cmake --build . --target format 
+  ```
 - Please try to follow the best practices and guidelines for your code's quality and documentation. This includes writing tests for your code. We do not enforce a specific coverage, but we expect reasonable tests for new code.
 - Please try to be short and concise with your commit messages. In case you want to provide more information, you can use the commit description.
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ you have a C++17 capable compiler and CMake installed.
 The project uses the following dependencies,
 all of them are **automatically** set-up via CMake:
 
-- GoogleTest (1.13.0 or compatible), only required for testing
+- GoogleTest (1.15.2 or compatible), only required for testing
 - spdlog (1.13.0 or compatible), required for logging
 - tetgen (1.6 or compatible), required for I/O
 - yaml-cpp (0.8.0 or compatible), required for I/O
@@ -309,7 +309,6 @@ The following options are available:
 |-------------------------------------------:|:--------------------------------------------------------------------------------------------|
 | POLYHEDRAL_GRAVITY_PARALLELIZATION (`CPP`) | `CPP` = Serial Execution / `OMP` or `TBB` = Parallel Execution with OpenMP or Intel\'s TBB  |
 |                     LOGGING_LEVEL (`INFO`) | `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`, `OFF`                                |
-|                      USE_LOCAL_TBB (`OFF`) | Use a local installation of `TBB` instead of setting it up via `CMake`                      |
 |      BUILD_POLYHEDRAL_GRAVITY_DOCS (`OFF`) | Build this documentation                                                                    |
 |      BUILD_POLYHEDRAL_GRAVITY_TESTS (`ON`) | Build the Tests                                                                             |
 |   BUILD_POLYHEDRAL_PYTHON_INTERFACE (`ON`) | Build the Python interface                                                                  |

--- a/cmake/clang_format.cmake
+++ b/cmake/clang_format.cmake
@@ -1,0 +1,27 @@
+file(GLOB_RECURSE CLANG_FORMAT_SRC
+        "${PROJECT_SOURCE_DIR}/src/*.cpp"
+        "${PROJECT_SOURCE_DIR}/src/*.h"
+        "${PROJECT_SOURCE_DIR}/test/*.cpp"
+        "${PROJECT_SOURCE_DIR}/test/*.h"
+)
+
+# Define a variable for clang-format command
+find_program(CLANG_FORMAT clang-format)
+
+# Ensure clang-format was found
+if(NOT CLANG_FORMAT)
+    message(STATUS "HPCLab: clang-format not found. Please install it to use clang-format via CMake")
+else()
+    message(STATUS "HPCLab: clang-format found. You can format all source files via `cmake --build . --target format`")
+    add_custom_command(
+            OUTPUT format_all_files
+            COMMAND ${CLANG_FORMAT} -i ${CLANG_FORMAT_SRC}
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+            COMMENT "Formatting all source and test files with clang-format"
+            VERBATIM
+    )
+
+    add_custom_target(format
+            DEPENDS format_all_files
+    )
+endif()

--- a/cmake/gtest.cmake
+++ b/cmake/gtest.cmake
@@ -1,18 +1,23 @@
 include(FetchContent)
 
-message(STATUS "Setting up gtest")
+message(STATUS "Setting up Google Test")
+set(GOOGLE_TEST_VERSION 1.15.2)
 
-#Adapted from https://cliutils.gitlab.io/modern-cmake/chapters/testing/googletest.html
-#Fetches the version 1.13.0 from the official github for googletest
-FetchContent_Declare(googletest
-        GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG v1.13.0
+find_package(GTest ${GOOGLE_TEST_VERSION} QUIET)
+
+
+if(${GTest_FOUND})
+        message(STATUS "Found existing Google Test: ${GTest_DIR}")
+else()
+        message(STATUS "Using Google Test from GitHub Release ${GOOGLE_TEST_VERSION}")
+
+        FetchContent_Declare(googletest
+                GIT_REPOSITORY https://github.com/google/googletest.git
+                GIT_TAG v${GOOGLE_TEST_VERSION}
         )
+        FetchContent_MakeAvailable(googletest)
 
-FetchContent_MakeAvailable(googletest)
-
-# Disable warnings from the library target
-target_compile_options(gtest_main PRIVATE -w)
-# Disable warnings from included headers
-get_target_property(propval gtest_main INTERFACE_INCLUDE_DIRECTORIES)
-target_include_directories(gtest_main SYSTEM PUBLIC "${propval}")
+        target_compile_options(gtest_main PRIVATE -w)
+        get_target_property(propval gtest_main INTERFACE_INCLUDE_DIRECTORIES)
+        target_include_directories(gtest_main SYSTEM PUBLIC "${propval}")
+endif()

--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -1,22 +1,18 @@
 include(FetchContent)
 
-message(STATUS "Setting up pybind11")
+message(STATUS "Setting up Pybind11 Library")
+set(PYBIND11_VERSION 2.12.0)
 
-find_package(pybind11 2.12.0 QUIET)
+find_package(pybind11 ${PYBIND11_VERSION} QUIET)
 
-if (${pybind11_FOUND})
-
-    message(STATUS "Using local pybind11 installation")
-
+if(${pybind11_FOUND})
+    message(STATUS "Found existing Pybind11 Library: ${pybind11_DIR}")
 else()
-
-    message(STATUS "Using pybind11 from git repository")
+    message(STATUS "Using Pybind11 Library from GitHub Release ${PYBIND11_VERSION}")
 
     FetchContent_Declare(pybind11
             GIT_REPOSITORY https://github.com/pybind/pybind11
-            GIT_TAG v2.12.0
+            GIT_TAG v${PYBIND11_VERSION}
     )
-
     FetchContent_MakeAvailable(pybind11)
-
 endif()

--- a/cmake/spdlog.cmake
+++ b/cmake/spdlog.cmake
@@ -1,33 +1,24 @@
 include(FetchContent)
 
 message(STATUS "Setting up spdlog")
+set(SPDLOG_VERSION 1.14.1)
 
-find_package(spdlog 1.13.0 QUIET)
+# Known Issue:
+# If you install spdlog@1.14.1 via homebrew on ARM macOS, CMake will find spdlog
+# However, there is a version mismatch between the `fmt` library installed as dependency, and the one actually
+# being required leading to a linking error (i.e. missing symbols) while compiling!
+find_package(spdlog ${SPDLOG_VERSION} QUIET)
 
-if (${spdlog_FOUND})
-
-    message(STATUS "Using existing spdlog installation")
-
+if(${spdlog_FOUND})
+    message(STATUS "Found existing spdlog Library: ${spdlog_DIR}")
 else()
-
-    message(STATUS "Using spdlog from git repository")
-
+    message(STATUS "Using Spdlog Library from GitHub Release ${SPDLOG_VERSION}")
     FetchContent_Declare(spdlog
             GIT_REPOSITORY https://github.com/gabime/spdlog.git
-            GIT_TAG v1.13.0
+            GIT_TAG v${SPDLOG_VERSION}
     )
-
-    # Disable stuff we don't need
-    option(SPDLOG_BUILD_EXAMPLE "" OFF)
-    option(SPDLOG_BUILD_TESTS "" OFF)
-    option(SPDLOG_INSTALL "" OFF)
-
+    set(SPDLOG_BUILD_EXAMPLE OFF CACHE BOOL "" FORCE)
+    set(SPDLOG_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(SPDLOG_INSTALL OFF CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(spdlog)
-
-    # Disable warnings from the library target
-    target_compile_options(spdlog PRIVATE -w)
-    # Disable warnings from included headers
-    get_target_property(propval spdlog INTERFACE_INCLUDE_DIRECTORIES)
-    target_include_directories(spdlog SYSTEM PUBLIC "${propval}")
-
 endif()

--- a/cmake/tbb.cmake
+++ b/cmake/tbb.cmake
@@ -1,15 +1,24 @@
 include(FetchContent)
 
-message(STATUS "Setting up tbb via CMake")
+message(STATUS "Setting up tbb")
+set(TBB_VERSION 2021.12.0)
 
-#Fetches the version v2021.12.0 from the official github of tbb
-FetchContent_Declare(tbb
-        GIT_REPOSITORY https://github.com/oneapi-src/oneTBB.git
-        GIT_TAG v2021.12.0
-)
+find_package(TBB QUIET HINTS /opt/homebrew/Cellar/tbb)
 
-# Disable tests & and do not treat tbb-compile errors as warnings
-option(TBB_TEST "Enable testing" OFF)
-option(TBB_STRICT "Treat compiler warnings as errors" OFF)
+if(${TBB_FOUND})
+    message(STATUS "Found existing TBB library: ${TBB_DIR}")
+else()
+    message(STATUS "Using TBB from GitHub Release ${TBB_VERSION}")
 
-FetchContent_MakeAvailable(tbb)
+    #Fetches the version v2021.12.0 from the official github of tbb
+    FetchContent_Declare(tbb
+            GIT_REPOSITORY https://github.com/oneapi-src/oneTBB.git
+            GIT_TAG v${TBB_VERSION}
+    )
+
+    # Disable tests & and do not treat tbb-compile errors as warnings
+    set(TBB_TEST OFF CACHE BOOL "" FORCE)
+    set(TBB_STRICT OFF CACHE BOOl "" FORCE)
+
+    FetchContent_MakeAvailable(tbb)
+endif()

--- a/cmake/thrust.cmake
+++ b/cmake/thrust.cmake
@@ -1,28 +1,26 @@
 include(FetchContent)
 
 message(STATUS "Setting up thrust")
+set(THRUST_VERSION 1.16.0)
 
 # Set custom variables, policies, etc.
 # Disable stuff not needed
 set(THRUST_ENABLE_HEADER_TESTING "OFF")
 set(THRUST_ENABLE_TESTING "OFF")
 set(THRUST_ENABLE_EXAMPLES "OFF")
-
 # Set standard CPP Dialect to 17 (default of thrust would be 14)
 set(THRUST_CPP_DIALECT 17)
 
-find_package(Thrust 1.16.0 QUIET)
+find_package(Thrust ${THRUST_VERSION} QUIET)
+
 
 if (${Thrust_FOUND})
-
-    message(STATUS "Using existing thrust installation")
-
+    message(STATUS "Found existing thrust installation: ${Thrust_DIR}")
 else()
-    message(STATUS "Using thrust from git repository")
-    # Fetches the version 1.16.0 of the official NVIDIA Thrust repository
+    message(STATUS "Using thrust from GitHub Release ${THRUST_VERSION}")
     FetchContent_Declare(thrust
             GIT_REPOSITORY https://github.com/NVIDIA/thrust.git
-            GIT_TAG 1.16.0
+            GIT_TAG ${THRUST_VERSION}
             )
     FetchContent_MakeAvailable(thrust)
 endif()

--- a/cmake/xsimd.cmake
+++ b/cmake/xsimd.cmake
@@ -1,24 +1,18 @@
 include(FetchContent)
 
-message(STATUS "Setting up xsimd via CMake")
+message(STATUS "Setting up xsimd Library")
+set(XSIMD_VERSION 11.1.0)
 
-
-find_package(xsimd 11.1 QUIET)
+find_package(xsimd ${XSIMD_VERSION} QUIET)
 
 if (${xsimd_FOUND})
-
-    message(STATUS "Using existing xsimd installation")
-
+    message(STATUS "Found existing xsimd Library: ${xsimd_DIR}")
 else()
-
-    message(STATUS "Using xsimd from git repository")
-
-    #Fetches the version 11.1.0 from the official github of tbb
+    message(STATUS "Using xsimd Library from GitHub Release ${XSIMD_VERSION}")
     FetchContent_Declare(xsimd
             GIT_REPOSITORY https://github.com/xtensor-stack/xsimd.git
-            GIT_TAG 11.1.0
+            GIT_TAG ${XSIMD_VERSION}
             )
 
     FetchContent_MakeAvailable(xsimd)
-
 endif()

--- a/cmake/yaml.cmake
+++ b/cmake/yaml.cmake
@@ -1,32 +1,27 @@
 include(FetchContent)
 
 message(STATUS "Setting up yaml-cpp")
+set(YAML_CPP_VERSION 0.8.0)
 
-find_package(yaml-cpp 0.8.0 QUIET)
+find_package(yaml-cpp ${YAML_CPP_VERSION} QUIET)
 
 if (${yaml-cpp_FOUND})
-
-    message(STATUS "Using existing yaml-cpp installation")
-
+    message(STATUS "Found existing yaml-cpp library: ${yaml-cpp_DIR}")
 else()
-
-    #Fetches the version 0.8.0 for yaml-cpp
+    message(STATUS "Using yaml-cpp from GitHub Release ${YAML_CPP_VERSION}")
     FetchContent_Declare(yaml-cpp
             GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-            GIT_TAG 0.8.0
+            GIT_TAG ${YAML_CPP_VERSION}
             )
-
     # Disable everything we don't need
     set(YAML_CPP_BUILD_TESTS OFF CACHE INTERNAL "")
     set(YAML_CPP_BUILD_CONTRIB OFF CACHE INTERNAL "")
     set(YAML_CPP_BUILD_TOOLS OFF CACHE INTERNAL "")
-
+    set(YAML_CPP_FORMAT_SOURCE OFF CACHE INTERNAL "")
     FetchContent_MakeAvailable(yaml-cpp)
-
     # Disable warnings from the library target
     target_compile_options(yaml-cpp PRIVATE -w)
     # Disable warnings from included headers
     get_target_property(propval yaml-cpp INTERFACE_INCLUDE_DIRECTORIES)
     target_include_directories(yaml-cpp SYSTEM PUBLIC "${propval}")
-
 endif()

--- a/docs/quickstart/installation.rst
+++ b/docs/quickstart/installation.rst
@@ -92,7 +92,6 @@ Name (Default)                                   Options
 ================================================ ===================================================================================================================================
 POLYHEDRAL_GRAVITY_PARALLELIZATION (:code:`CPP`) :code:`CPP` = Serial Execution / :code:`OMP` or :code:`TBB`  = Parallel Execution with OpenMP or Intel's TBB
 LOGGING_LEVEL (:code:`INFO`)                     :code:`TRACE`, :code:`DEBUG`, :code:`INFO`, :code:`WARN`, :code:`ERROR`, :code:`CRITICAL`, :code:`OFF`
-USE_LOCAL_TBB (:code:`OFF`)                      Use a local installation of :code:`TBB` instead of setting it up via :code:`CMake`
 BUILD_POLYHEDRAL_GRAVITY_DOCS (:code:`OFF`)      Build this documentation
 BUILD_POLYHEDRAL_GRAVITY_TESTS (:code:`ON`)      Build the Tests
 BUILD_POLYHEDRAL_PYTHON_INTERFACE (:code:`ON`)   Build the Python interface
@@ -104,7 +103,7 @@ Dependencies (automatically set-up)
 
 Dependencies (all of them are automatically set-up via :code:`CMake`):
 
-- GoogleTest (1.13.0 or compatible), only required for testing
+- GoogleTest (1.15.2 or compatible), only required for testing
 - spdlog (1.13.0 or compatible), required for logging
 - tetgen (1.6 or compatible), required for I/O
 - yaml-cpp (0.8.0 or compatible), required for I/O

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,8 @@ name: polyhedral-gravity-env
 channels:
   - conda-forge
 dependencies:
+  - python==3.12
+  - setuptools
   - numpy
   - pytest
   - pytest-xdist

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,6 @@ CMAKE_OPTIONS = {
     "POLYHEDRAL_GRAVITY_PARALLELIZATION": "TBB",
     # Default value (INFO=2)
     "LOGGING_LEVEL": "INFO",
-    # Default value (OFF)
-    "USE_LOCAL_TBB": "OFF",
     # Not required for the python interface (--> OFF)
     "BUILD_POLYHEDRAL_GRAVITY_DOCS": "OFF",
     # Not required for the python interface (--> OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ if (BUILD_POLYHEDRAL_GRAVITY_LIBRARY)
     # Link libraries needed in all targets
     target_link_libraries(${PROJECT_NAME}_lib
             spdlog::spdlog
-            yaml-cpp
+            yaml-cpp::yaml-cpp
             tetgen
             xsimd
             Thrust

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,8 +12,9 @@ add_executable(${PROJECT_NAME}_test ${TEST_SRC})
 
 # Links target breakupModelTest against gtest_main (entry point, so no own main method is required)
 target_link_libraries(${PROJECT_NAME}_test
-        gtest_main
-        gmock
+        GTest::gtest_main
+        GTest::gtest
+        GTest::gmock
         ${PROJECT_NAME}_lib
         )
 


### PR DESCRIPTION
# Changelog

- Update CMake Dependency Files
- Add CMake Target for formatting files according to `.clang-format` and mention it in `CONTRIBUTING.md`
- Update deprecated Mamba Setup in GitHub Actions CI/ CD
- Remove the `USE_LOCAL_TBB` option --> Now, this is properly solved by a proper `find_package` call (redirecting to `FetchContent` if not found)
- Fix issues with `yaml-cpp` not being properly linked when already pre-installed on the system