### PR TITLE
Add CMake policy version to Release Pipeline

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Release ..
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
           cmake --build . --config Release
       - name: Test (Linux & macOS)
         run: cd build/test && ./polyhedralGravity_test

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,9 @@ CMAKE_OPTIONS = {
     # Should be of course ON!
     "BUILD_POLYHEDRAL_GRAVITY_PYTHON_INTERFACE": "ON",
     # Build static libs by default (On conda-forge we build shared libs by setting this to ON)
-    "BUILD_SHARED_LIBS": "OFF"
+    "BUILD_SHARED_LIBS": "OFF",
+    # Required since CMake 4.0 (doesn't do anything before that) due to the outdated TetGen build system
+    "CMAKE_POLICY_VERSION_MINIMUM": "3.5",
 }
 # ---------------------------------------------------------------------------------
 

--- a/version.cmake
+++ b/version.cmake
@@ -1,5 +1,5 @@
 # Modify the version with a new release
-set(PROJECT_VERSION 3.3)
+set(PROJECT_VERSION 3.3rc2)
 set(POLYHEDRAL_GRAVITY_VERSION ${PROJECT_VERSION})
 
 # Get the Git information

--- a/version.cmake
+++ b/version.cmake
@@ -1,5 +1,5 @@
 # Modify the version with a new release
-set(PROJECT_VERSION 3.3rc2)
+set(PROJECT_VERSION 3.3)
 set(POLYHEDRAL_GRAVITY_VERSION ${PROJECT_VERSION})
 
 # Get the Git information


### PR DESCRIPTION
# Fix Release Pipeline v3.3.0

Add `CMAKE_POLICY_VERSION_MINIMUM` to support newer CMake versions and accommodate outdated TetGen build systems.