### PR TITLE
Bits Bytes and Fixes

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,7 +31,7 @@ jobs:
           platforms: all
         if: matrix.os == 'ubuntu-latest'
       - name: Build wheels (Linux)
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v3.1.4
         env:
           CIBW_BEFORE_BUILD: pipx install ninja cmake
           CIBW_ENABLE: cpython-freethreading pypy
@@ -47,7 +47,7 @@ jobs:
       # For the x86_64, we set the MACOSX_DEPLOYMENT_TARGET='10.15' (released 2019) in order to have support for C++17
       # We don't need this for arm64 since macOS arm64 initially supported C++17/ came years later than macOS 10.15
       - name: Build wheels (macOS)
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v3.1.4
         env:
           CIBW_BEFORE_BUILD: pipx install ninja cmake
           CIBW_ENABLE: cpython-freethreading pypy
@@ -65,10 +65,10 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
         if: matrix.os == 'windows-latest'
       - name: Build wheels (Windows)
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v3.1.4
         env:
           CIBW_BEFORE_BUILD: pipx install ninja cmake
-          CIBW_ENABLE: pypy # cpython-freethreading is not yet working on Windows
+          CIBW_ENABLE: pypy cpython-freethreading
           CIBW_ARCHS_WINDOWS: "auto64"
           CIBW_TEST_COMMAND: 'python -c "import polyhedral_gravity"'
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,14 +44,14 @@ jobs:
       ############################# MACOS WHEELS #############################
       # We use Apple Clang as it is the only compiler offering cross-compiling for x86_64
       # The macOS GitHub Runner is nowadays arm64 based
-      # For the x86_64, we set the MACOSX_DEPLOYMENT_TARGET='10.13' (released 2017) in order to have support for C++17
-      # We don't need this for arm64 since macOS arm64 initially supported C++17/ came years later than macOS 10.13
+      # For the x86_64, we set the MACOSX_DEPLOYMENT_TARGET='10.15' (released 2019) in order to have support for C++17
+      # We don't need this for arm64 since macOS arm64 initially supported C++17/ came years later than macOS 10.15
       - name: Build wheels (macOS)
         uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_BEFORE_BUILD: pipx install ninja cmake
           CIBW_ENABLE: cpython-freethreading pypy
-          CIBW_ENVIRONMENT: 'MACOSX_DEPLOYMENT_TARGET="10.13"'
+          CIBW_ENVIRONMENT: 'MACOSX_DEPLOYMENT_TARGET="10.15"'
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_TEST_COMMAND: 'python -c "import polyhedral_gravity"'
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if (_LIBCPP_DISABLE_AVAILABILITY)
     add_definitions(-D_LIBCPP_DISABLE_AVAILABILITY)
 endif ()
 
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang")
+if (${APPLE} AND (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))
     # Fixes undefined _VSTD when using Apple Clang 17
     message(STATUS "Using Apple Clang compiler. Defining _VSTD=std.")
     add_definitions(-D_VSTD=std)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if (_LIBCPP_DISABLE_AVAILABILITY)
     add_definitions(-D_LIBCPP_DISABLE_AVAILABILITY)
 endif ()
 
-if (${APPLE} AND (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" AND (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))
     # Fixes undefined _VSTD when using Apple Clang 17
     message(STATUS "Using Apple Clang compiler. Defining _VSTD=std.")
     add_definitions(-D_VSTD=std)

--- a/cmake/git.cmake
+++ b/cmake/git.cmake
@@ -44,3 +44,15 @@ function(is_git_working_tree_clean OUTPUT_VAR)
         endif()
     endif()
 endfunction()
+
+# Based on https://github.com/Blauben/kd-tree/blob/d1b271f898248a8e22750545c075b42e58432f7d/cmake/git.cmake#L48
+function(get_git_version_tag OUTPUT_VAR)
+    execute_process(
+            COMMAND git describe --tags --match "v[0-9]*.[0-9]*.[0-9]*"
+            OUTPUT_VARIABLE GIT_TAG
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    string(LENGTH ${GIT_TAG} TAG_LENGTH)
+    string(SUBSTRING ${GIT_TAG} 1 ${TAG_LENGTH} VERSION_NUMBER)
+    set(${OUTPUT_VAR} "${VERSION_NUMBER}" PARENT_SCOPE)
+endfunction()

--- a/cmake/git.cmake
+++ b/cmake/git.cmake
@@ -48,8 +48,16 @@ endfunction()
 # Based on https://github.com/Blauben/kd-tree/blob/d1b271f898248a8e22750545c075b42e58432f7d/cmake/git.cmake#L48
 function(get_git_version_tag OUTPUT_VAR)
     execute_process(
-            COMMAND git describe --tags --match "v[0-9]*.[0-9]*.[0-9]*"
+            COMMAND git describe --tags --abbrev=0
+            --match v[0-9]*.[0-9]*.[0-9]*        # plain
+            --match v[0-9]*.[0-9]*.[0-9]*a*      # alpha
+            --match v[0-9]*.[0-9]*.[0-9]*b*      # beta
+            --match v[0-9]*.[0-9]*.[0-9]*rc*     # release candidate
+            --match v[0-9]*.[0-9]*.[0-9]*.post*  # post
+            --match v[0-9]*.[0-9]*.[0-9]*.dev*   # dev
             OUTPUT_VARIABLE GIT_TAG
+            ERROR_VARIABLE GIT_TAG_ERR
+            RESULT_VARIABLE GIT_TAG_RES
             OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     string(LENGTH ${GIT_TAG} TAG_LENGTH)

--- a/cmake/git.cmake
+++ b/cmake/git.cmake
@@ -1,7 +1,12 @@
-find_package(Git QUIET REQUIRED)
+find_package(Git QUIET)
 
 function(get_git_commit_hash OUTPUT_VAR)
     # Run a Git command to get the first 8 characters of the current commit hash
+    if(NOT GIT_FOUND OR NOT GIT_EXECUTABLE)
+        set(${OUTPUT_VAR} "Unknown" PARENT_SCOPE)
+        return()
+    endif()
+
     execute_process(
             COMMAND ${GIT_EXECUTABLE} rev-parse --short=8 HEAD
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -23,6 +28,11 @@ endfunction()
 
 function(is_git_working_tree_clean OUTPUT_VAR)
     # Run a Git command to check if the working tree is clean
+    if(NOT GIT_FOUND OR NOT GIT_EXECUTABLE)
+        set(${OUTPUT_VAR} "Unknown" PARENT_SCOPE)
+        return()
+    endif()
+
     execute_process(
             COMMAND ${GIT_EXECUTABLE} diff-index --quiet HEAD --
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -45,8 +55,13 @@ function(is_git_working_tree_clean OUTPUT_VAR)
     endif()
 endfunction()
 
-# Based on https://github.com/Blauben/kd-tree/blob/d1b271f898248a8e22750545c075b42e58432f7d/cmake/git.cmake#L48
 function(get_git_version_tag OUTPUT_VAR)
+    # Runs a git command to return the latest version number (given the most similar git tag)
+    if(NOT GIT_FOUND OR NOT GIT_EXECUTABLE)
+        set(${OUTPUT_VAR} "Unknown" PARENT_SCOPE)
+        return()
+    endif()
+
     execute_process(
             COMMAND git describe --tags --abbrev=0
             --match v[0-9]*.[0-9]*.[0-9]*        # plain

--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -1,7 +1,8 @@
 include(FetchContent)
 
 message(STATUS "Setting up Pybind11 Library")
-set(PYBIND11_VERSION 2.12.0)
+set(PYBIND11_VERSION 3.0.1)
+set(PYBIND11_FINDPYTHON ON)
 
 find_package(pybind11 ${PYBIND11_VERSION} QUIET)
 

--- a/setup.py
+++ b/setup.py
@@ -56,24 +56,11 @@ def get_cmake_generator():
         return None
 
 def get_version():
-    """Returns the version of the polyhedral gravity package by reading the CMake file."""
-    # Path to the CMake file
-    cmake_file = os.path.join(os.path.dirname(__file__), "version.cmake" )
-
-    # Check if the CMake file exists
-    if not os.path.exists(cmake_file):
-        raise FileNotFoundError(f"CMake file not found: {cmake_file}")
-
-    # Open and read the file
-    with open(cmake_file, "r") as file:
-        content = file.read()
-
-    # Use regex to extract the PROJECT_VERSION
-    version_match = re.search(r'set\(PROJECT_VERSION\s+([^\s)]+)\)', content)
-    if version_match:
-        return version_match.group(1)
-    else:
-        raise ValueError("Version string not found in CMakeLists.txt")
+    """Returns the version of the polyhedral gravity package by using git describe"""
+    version_string = subprocess.check_output([ "git", "describe", "--tags", "--match", "v[0-9]*.[0-9]*.[0-9]*"]).decode("utf-8")
+    # The output looks like 'v3.3.0-1-g98405d2\n' or 'v3.3.0\n' depending on whether the commit has been directly tagged or not
+    # We only want the initial version number without the git commit hash
+    return re.search(r"v(\d+\.\d+\.\d+)", version_string).group(1)
 
 
 # -----------------------------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ def get_cmake_generator():
     else:
         return None
 
-def get_version():
+def get_git_version():
     """Returns the version of the polyhedral gravity package by using git describe"""
     version_string = subprocess.check_output([
         "git", "describe", "--tags", "--abbrev=0",
@@ -68,6 +68,26 @@ def get_version():
     ]).decode("utf-8").strip()
     # Remove the leading "v"
     return version_string[1:]
+
+def get_cmake_version():
+    """Returns the version of the polyhedral gravity package by reading the CMake file."""
+    # Path to the CMake file
+    cmake_file = os.path.join(os.path.dirname(__file__), "version.cmake" )
+
+    # Check if the CMake file exists
+    if not os.path.exists(cmake_file):
+        raise FileNotFoundError(f"CMake file not found: {cmake_file}")
+
+    # Open and read the file
+    with open(cmake_file, "r") as file:
+        content = file.read()
+
+    # Use regex to extract the PROJECT_VERSION
+    version_match = re.search(r'set\(POLYHEDRAL_GRAVITY_VERSION\s+"(.*)"', content)
+    if version_match:
+        return version_match.group(1)
+    else:
+        raise ValueError("Version string not found in CMakeLists.txt")
 
 
 # -----------------------------------------------------------------------------------------
@@ -190,7 +210,7 @@ picture_in_readme = '''<p align="center">
 # --------------------------------------------------------------------------------
 setup(
     name="polyhedral_gravity",
-    version=get_version(),
+    version=get_cmake_version(),
     author="Jonas Schuhmacher",
     author_email="jonas.schuhmacher@tum.de",
     description="Package to compute full gravity tensor of a given constant density polyhedron for arbitrary points "

--- a/setup.py
+++ b/setup.py
@@ -66,9 +66,8 @@ def get_version():
         "--match", "v[0-9]*.[0-9]*.[0-9]*.post*",  # post
         "--match", "v[0-9]*.[0-9]*.[0-9]*.dev*",   # dev
     ]).decode("utf-8").strip()
-    # The output looks like 'v3.3.0-1-g98405d2\n' or 'v3.3.0\n' depending on whether the commit has been directly tagged or not
-    # We only want the initial version number without the git commit hash
-    return version_string.split("-")[0][1:]
+    # Remove the leading "v"
+    return version_string[1:]
 
 
 # -----------------------------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ setup(
     license="GPLv3",
     license_file="LICENSE",
     zip_safe=False,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     include_package_data=True,
     project_urls={
         "Homepage": "https://github.com/esa/polyhedral-gravity-model",

--- a/setup.py
+++ b/setup.py
@@ -57,10 +57,18 @@ def get_cmake_generator():
 
 def get_version():
     """Returns the version of the polyhedral gravity package by using git describe"""
-    version_string = subprocess.check_output([ "git", "describe", "--tags", "--match", "v[0-9]*.[0-9]*.[0-9]*"]).decode("utf-8")
+    version_string = subprocess.check_output([
+        "git", "describe", "--tags", "--abbrev=0",
+        "--match", "v[0-9]*.[0-9]*.[0-9]*",        # plain
+        "--match", "v[0-9]*.[0-9]*.[0-9]*a*",      # alpha
+        "--match", "v[0-9]*.[0-9]*.[0-9]*b*",      # beta
+        "--match", "v[0-9]*.[0-9]*.[0-9]*rc*",     # release candidate
+        "--match", "v[0-9]*.[0-9]*.[0-9]*.post*",  # post
+        "--match", "v[0-9]*.[0-9]*.[0-9]*.dev*",   # dev
+    ]).decode("utf-8").strip()
     # The output looks like 'v3.3.0-1-g98405d2\n' or 'v3.3.0\n' depending on whether the commit has been directly tagged or not
     # We only want the initial version number without the git commit hash
-    return re.search(r"v(\d+\.\d+\.\d+)", version_string).group(1)
+    return version_string.split("-")[0][1:]
 
 
 # -----------------------------------------------------------------------------------------

--- a/src/polyhedralGravity/input/MeshReader.cpp
+++ b/src/polyhedralGravity/input/MeshReader.cpp
@@ -6,6 +6,12 @@
 namespace polyhedralGravity {
 
     PolyhedralSource MeshReader::getPolyhedralSource(const std::vector<std::string> &fileNames) {
+        // Input Sanity Check if the files exists
+        for (const auto &fileName: fileNames) {
+            if (!std::filesystem::exists(fileName)) {
+                throw std::runtime_error("File '" + fileName + "' does not exist.");
+            }
+        }
         switch (fileNames.size()) {
             case 0:
                 throw std::runtime_error("No mesh file given");

--- a/src/polyhedralGravity/input/MeshReader.h
+++ b/src/polyhedralGravity/input/MeshReader.h
@@ -11,6 +11,7 @@
 #include "polyhedralGravity/util/UtilityContainer.h"
 #include <exception>
 #include <stdexcept>
+#include <filesystem>
 
 namespace polyhedralGravity {
 
@@ -23,7 +24,8 @@ namespace polyhedralGravity {
          * Returns a polyhedral source consisting of vertices and faces by reading mesh input files.
          * @param fileNames files specifying a polyhedron
          * @return polyhedral source consisting of vertices and faces
-         * @throws std::invalid_argument exception if the file type is unsupported by the implementation
+         * @throws std::invalid_argument if the file type is unsupported by the implementation
+         * @throws std::runtime_error if the provided files do not exist
          */
         PolyhedralSource getPolyhedralSource(const std::vector<std::string> &fileNames);
 

--- a/src/polyhedralGravityPython/PolyhedralGravityPython.cpp
+++ b/src/polyhedralGravityPython/PolyhedralGravityPython.cpp
@@ -15,7 +15,7 @@
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(polyhedral_gravity, m) {
+PYBIND11_MODULE(polyhedral_gravity, m, py::mod_gil_not_used()) {
     using namespace polyhedralGravity;
     m.doc() = R"mydelimiter(
     The evaluation of the polyhedral gravity model requires the following parameters:

--- a/src/polyhedralGravityPython/PolyhedralGravityPython.cpp
+++ b/src/polyhedralGravityPython/PolyhedralGravityPython.cpp
@@ -175,6 +175,7 @@ PYBIND11_MODULE(polyhedral_gravity, m) {
 
             Raises:
                 ValueError: If :code:`integrity_check` is set to :code:`AUTOMATIC` or :code:`VERIFY` and the mesh is inconsistent
+                RuntimeError: If files given as :code:`polyhedral_source` do not exist
 
             Note:
                 The :code:`integrity_check` is automatically enabled to avoid wrong results due to the wrong vertex ordering.

--- a/test/model/PolyhedronTest.cpp
+++ b/test/model/PolyhedronTest.cpp
@@ -335,3 +335,13 @@ TEST_F(PolyhedronTest, CorrectBigPolyhedron) {
             );
 }
 
+TEST_F(PolyhedronTest, FileDoesNotExistPolyhedron) {
+    using namespace testing;
+    using namespace polyhedralGravity;
+    // All normals are pointing outwards, extensive Eros example
+    ASSERT_THROW(Polyhedron(
+                std::vector<std::string>({"resources/FileDoesNotExist.node", "resources/FileDoesNotExist.face"}),
+                1.0, NormalOrientation::OUTWARDS, PolyhedronIntegrity::VERIFY), std::runtime_error
+            );
+}
+

--- a/test/python/test_polyhedron.py
+++ b/test/python/test_polyhedron.py
@@ -113,3 +113,11 @@ def test_polyhedron_metric() -> None:
     )
     assert unitless_polyhedron.density_unit == "unitless"
     assert unitless_polyhedron.mesh_unit == "unitless"
+
+def test_failed_polyhedral_construction() -> None:
+    """Tests if the construction of a Polyhedron fails when the source is invalid."""
+    with pytest.raises(RuntimeError):
+        Polyhedron(
+            polyhedral_source=["test/resources/FileDoesNotExist.node", "test/resources/FileDoesNotExist.face"],
+            density=1.0,
+        )

--- a/version.cmake
+++ b/version.cmake
@@ -1,10 +1,8 @@
-# Modify the version with a new release
-set(PROJECT_VERSION 3.3)
-set(POLYHEDRAL_GRAVITY_VERSION ${PROJECT_VERSION})
-
 # Get the Git information
 get_git_commit_hash(POLYHEDRAL_GRAVITY_COMMIT_HASH)
 is_git_working_tree_clean(POLYHEDRAL_GRAVITY_WORKING_TREE)
+get_git_version_tag(POLYHEDRAL_GRAVITY_VERSION)
+set(${PROJECT_VERSION} ${POLYHEDRAL_GRAVITY_VERSION})
 
 # Append "-modified" to the commit hash if the working tree is not clean
 if (NOT ${POLYHEDRAL_GRAVITY_WORKING_TREE})

--- a/version.cmake
+++ b/version.cmake
@@ -1,7 +1,8 @@
 # Get the Git information
 get_git_commit_hash(POLYHEDRAL_GRAVITY_COMMIT_HASH)
 is_git_working_tree_clean(POLYHEDRAL_GRAVITY_WORKING_TREE)
-get_git_version_tag(POLYHEDRAL_GRAVITY_VERSION)
+# The Regex of the setup.py captures everything inside the quotes!
+set(POLYHEDRAL_GRAVITY_VERSION "3.3.1rc1")
 set(${PROJECT_VERSION} ${POLYHEDRAL_GRAVITY_VERSION})
 
 # Append "-modified" to the commit hash if the working tree is not clean

--- a/version.cmake
+++ b/version.cmake
@@ -2,7 +2,7 @@
 get_git_commit_hash(POLYHEDRAL_GRAVITY_COMMIT_HASH)
 is_git_working_tree_clean(POLYHEDRAL_GRAVITY_WORKING_TREE)
 # The Regex of the setup.py captures everything inside the quotes!
-set(POLYHEDRAL_GRAVITY_VERSION "3.3.1rc1")
+set(POLYHEDRAL_GRAVITY_VERSION "3.3.1rc2")
 set(${PROJECT_VERSION} ${POLYHEDRAL_GRAVITY_VERSION})
 
 # Append "-modified" to the commit hash if the working tree is not clean

--- a/version.cmake
+++ b/version.cmake
@@ -2,7 +2,7 @@
 get_git_commit_hash(POLYHEDRAL_GRAVITY_COMMIT_HASH)
 is_git_working_tree_clean(POLYHEDRAL_GRAVITY_WORKING_TREE)
 # The Regex of the setup.py captures everything inside the quotes!
-set(POLYHEDRAL_GRAVITY_VERSION "3.3.1rc2")
+set(POLYHEDRAL_GRAVITY_VERSION "3.3.1")
 set(${PROJECT_VERSION} ${POLYHEDRAL_GRAVITY_VERSION})
 
 # Append "-modified" to the commit hash if the working tree is not clean


### PR DESCRIPTION
# Changelog Version 3.3.1

- ~Automatic parsing of the version number based on the most recent git tag~
  - Deactivated because it leads to issues:
    - Not possible if downloading the `zip` or `tar.gz` release as conda does, since this does not contain the `git` history
    - Not possible if only a partial git history is available (like in the GitHub CI)
  - However, I did keep the function available in the CMake Build System
- Resolves #49 
  - A runtime error is thrown if the `Polyhedron`'s source files don't exist
- Update PyPI Build Wheels and Pybind11 Dependency to enable Python 3.14 builds and Windows 3.13-free-threaded builds
- Drop official "support" for the deprecated Python 3.8 (The module can still be built for 3.8 and older versions. However, GitHub's maximum runner duration is 6 hours - We simply cannot build wheels for all versions in time)