### PR TITLE
fix: correct vertex singularity detection in computeSingularityTerms

### DIFF
--- a/src/polyhedralGravity/model/GravityModelDetail.cpp
+++ b/src/polyhedralGravity/model/GravityModelDetail.cpp
@@ -338,8 +338,8 @@ namespace polyhedralGravity::GravityModel::detail {
             const double segmentVectorNorm = euclideanNorm(segmentVector);
             return projectionPointVertexNorms[(j + 1) % 3] < segmentVectorNorm &&
                    projectionPointVertexNorms[j] < segmentVectorNorm &&
-                   projectionPointVertexNorms[(j + 1) % 3] > EPSILON_ZERO_OFFSET &&
-                   projectionPointVertexNorms[j] > EPSILON_ZERO_OFFSET;
+                   projectionPointVertexNorms[(j + 1) % 3] >= EPSILON_ZERO_OFFSET &&
+                   projectionPointVertexNorms[j] >= EPSILON_ZERO_OFFSET;
         })) {
             using namespace util;
             return std::make_pair(-1.0 * util::PI * planeDistance,                                //sing alpha = -pi*h_p

--- a/src/polyhedralGravity/model/GravityModelDetail.cpp
+++ b/src/polyhedralGravity/model/GravityModelDetail.cpp
@@ -337,7 +337,9 @@ namespace polyhedralGravity::GravityModel::detail {
 
             const double segmentVectorNorm = euclideanNorm(segmentVector);
             return projectionPointVertexNorms[(j + 1) % 3] < segmentVectorNorm &&
-                   projectionPointVertexNorms[j] < segmentVectorNorm;
+                   projectionPointVertexNorms[j] < segmentVectorNorm &&
+                   projectionPointVertexNorms[(j + 1) % 3] > EPSILON_ZERO_OFFSET &&
+                   projectionPointVertexNorms[j] > EPSILON_ZERO_OFFSET;
         })) {
             using namespace util;
             return std::make_pair(-1.0 * util::PI * planeDistance,                                //sing alpha = -pi*h_p
@@ -369,8 +371,8 @@ namespace polyhedralGravity::GravityModel::detail {
         })) {
             using namespace util;
             //Two segment vectors G_1 and G_2 of this plane
-            const Array3 &g1 = r1Norm == 0.0 ? segmentVectorsForPlane[j] : segmentVectorsForPlane[(j - 1 + 3) % 3];
-            const Array3 &g2 = r1Norm == 0.0 ? segmentVectorsForPlane[(j + 1) % 3] : segmentVectorsForPlane[j];
+            const Array3 &g1 = r1Norm < EPSILON_ZERO_OFFSET ? segmentVectorsForPlane[j] : segmentVectorsForPlane[(j - 1 + 3) % 3];
+            const Array3 &g2 = r1Norm < EPSILON_ZERO_OFFSET ? segmentVectorsForPlane[(j + 1) % 3] : segmentVectorsForPlane[j];
             // theta = arcos((G_2 * -G_1) / (|G_2| * |G_1|))
             const double gdot = dot(g1 * -1.0, g2);
             const double theta = gdot == 0.0 ? util::PI_2 : std::acos(gdot / (euclideanNorm(g1) * euclideanNorm(g2)));


### PR DESCRIPTION
## Summary

  - Floating-point arithmetic could cause `computeSingularityTerms` to select the edge singularity path (Case 2) instead of the vertex singularity path (Case 3) for query points whose projection P' lands at a face vertex.
  - The g1/g2 branch selection in Case 3 used an exact `== 0.0` comparison inconsistent with the `< EPSILON_ZERO_OFFSET` threshold used everywhere else in the function.

## Root cause

When P' projects onto a vertex, floating-point arithmetic produces `rvn[(j+1)%3] ≈ ~|G| - eps` instead of exactly `|G|`. This satisfies the Case 2 condition `rvn < |G|`, firing the edge singularity formula `-pi * h_p` instead of the correct vertex formula `-theta * h_p`.

## Changes

  - **Case 2 guard:** added `>= EPSILON_ZERO_OFFSET` on both vertex-distance norms so near-vertex points (norm < ε) fall through to Case 3.
  - **Case 3 g1/g2 selection:** replaced `r1Norm == 0.0` with `r1Norm < EPSILON_ZERO_OFFSET` for consistency with the rest of the function.

  ## Verification

 Create a right-angle tetrahedron with vertices `(0,0,0)`, `(2,0,0)`, `(0,2,0)`, `(0,0,2)` and query point `(10, 0, z)`.
 Changing z and comparing the potential produced by original vs fixed you obtain:

  | z | original | fixed |
  |---|----------|-------|
  | 1e-10 | 9.34e-12 | 9.34e-12 |
  | 1e-12 | 9.34e-12 | 9.34e-12 |
  | 1e-13 | 9.34e-12 | 9.34e-12 |
  | 1e-14 | **-5.23e-09**| **-5.23e-09** |
  | 1e-15 | **-5.23e-09**| 9.34e-12 |
  | sin(pi) ≈ 1.22e-16 | **-5.23e-09** | 9.34e-12 |
  | 1e-16 | 9.34e-12 | 9.34e-12 |
  | 1e-17 | 9.34e-12 | 9.34e-12 |
  | 0.0 (exact vertex) | 9.34e-12 | 9.34e-12 |

Discontinuities are highlighted in bold.

All existing tests pass.

### Remaining bugs!!!
`z = 1e-14`  shows a pre-existing discontinuity in both the original and fixed code, which I was not able to fix. It could be related with `EPSILON_ZERO_OFFSET` being exactly `1e-14`